### PR TITLE
Fixed mistakes in HTTP tutorials

### DIFF
--- a/tutorials/2.2/network-http-fr.php
+++ b/tutorials/2.2/network-http-fr.php
@@ -87,7 +87,7 @@ sf::Http::Response response = http.sendRequest(request);
 std::cout &lt;&lt; "status: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
 std::cout &lt;&lt; "HTTP version: " &lt;&lt; response.getMajorHttpVersion() &lt;&lt; "." &lt;&lt; response.getMinorHttpVersion() &lt;&lt; std::endl;
 std::cout &lt;&lt; "Content-Type header:" &lt;&lt; response.getField("Content-Type") &lt;&lt; std::endl;
-std::cout &lt;&lt; "body: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
+std::cout &lt;&lt; "body: " &lt;&lt; response.getBody() &lt;&lt; std::endl;
 </code></pre>
 <p>
     Le code de statut peut être utilisé pour vérifier si la requête a été traitée avec succès ou non : les codes 2xx informent que tout s'est bien passé, les codes 3xx

--- a/tutorials/2.2/network-http.php
+++ b/tutorials/2.2/network-http.php
@@ -85,7 +85,7 @@ sf::Http::Response response = http.sendRequest(request);
 std::cout &lt;&lt; "status: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
 std::cout &lt;&lt; "HTTP version: " &lt;&lt; response.getMajorHttpVersion() &lt;&lt; "." &lt;&lt; response.getMinorHttpVersion() &lt;&lt; std::endl;
 std::cout &lt;&lt; "Content-Type header:" &lt;&lt; response.getField("Content-Type") &lt;&lt; std::endl;
-std::cout &lt;&lt; "body: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
+std::cout &lt;&lt; "body: " &lt;&lt; response.getBody() &lt;&lt; std::endl;
 </code></pre>
 <p>
     The status code can be used to check whether the request was successfully processed or not: codes 2xx represent success, codes 3xx represent a redirection, codes 4xx represent client

--- a/tutorials/2.3/network-http-fr.php
+++ b/tutorials/2.3/network-http-fr.php
@@ -87,7 +87,7 @@ sf::Http::Response response = http.sendRequest(request);
 std::cout &lt;&lt; "status: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
 std::cout &lt;&lt; "HTTP version: " &lt;&lt; response.getMajorHttpVersion() &lt;&lt; "." &lt;&lt; response.getMinorHttpVersion() &lt;&lt; std::endl;
 std::cout &lt;&lt; "Content-Type header:" &lt;&lt; response.getField("Content-Type") &lt;&lt; std::endl;
-std::cout &lt;&lt; "body: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
+std::cout &lt;&lt; "body: " &lt;&lt; response.getBody() &lt;&lt; std::endl;
 </code></pre>
 <p>
     Le code de statut peut être utilisé pour vérifier si la requête a été traitée avec succès ou non : les codes 2xx informent que tout s'est bien passé, les codes 3xx

--- a/tutorials/2.3/network-http.php
+++ b/tutorials/2.3/network-http.php
@@ -85,7 +85,7 @@ sf::Http::Response response = http.sendRequest(request);
 std::cout &lt;&lt; "status: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
 std::cout &lt;&lt; "HTTP version: " &lt;&lt; response.getMajorHttpVersion() &lt;&lt; "." &lt;&lt; response.getMinorHttpVersion() &lt;&lt; std::endl;
 std::cout &lt;&lt; "Content-Type header:" &lt;&lt; response.getField("Content-Type") &lt;&lt; std::endl;
-std::cout &lt;&lt; "body: " &lt;&lt; response.getStatus() &lt;&lt; std::endl;
+std::cout &lt;&lt; "body: " &lt;&lt; response.getBody() &lt;&lt; std::endl;
 </code></pre>
 <p>
     The status code can be used to check whether the request was successfully processed or not: codes 2xx represent success, codes 3xx represent a redirection, codes 4xx represent client


### PR DESCRIPTION
Fixed small mistake in [HTTP tutorial](http://www.sfml-dev.org/tutorials/2.3/network-http.php#responses):

```cpp
std::cout << "body: " << response.getStatus() << std::endl;
```
to:
```cpp
std::cout << "body: " << response.getBody() << std::endl;
```

Ironically, the mistake was only introduced for SFML 2.2, so the 2.0 and 2.1 tutorials need not be changed.