### PR TITLE
Update information for Rust bindings

### DIFF
--- a/download/bindings.php
+++ b/download/bindings.php
@@ -127,8 +127,8 @@
         </tr>
         <tr>
             <th rowspan="1">Rust</th>
-            <td><a href="http://www.rust-sfml.org/" class="website"><img src="../images/bindings/rust-sfml.png" alt="rust-sfml"></a></td>
-            <td>2.1</td>
+            <td><a href="https://github.com/jeremyletang/rust-sfml" class="website"><img src="../images/bindings/rust-sfml.png" alt="rust-sfml"></a></td>
+            <td>2.3</td>
             <td><a href="mailto:letang.jeremy@gmail.com">Jérémy Letang</a></td>
         </tr>
     </tbody>


### PR DESCRIPTION
- Update link to point to GitHub repository instead of home page. The home page is unmaintained, and severely outdated.
- Increment supported version to 2.3