### PR TITLE
Community and home page - stagger column separation.

### DIFF
--- a/community-fr.php
+++ b/community-fr.php
@@ -9,7 +9,7 @@
 <h1>Communauté</h1>
 
 <div class="home-section">
-    <div class="community-column-wide">
+    <div class="stagger-column-wide">
         <div class="title">&raquo; <a href="http://fr.sfml-dev.org/forums/" title="Aller au forum">Forum</a></div>
         <p>
             Que vous ayez une question concernant l'<a href="learn-fr.php" title="Aller à la page des tutoriels et de la documentation">API</a>, que vous rencontriez des comportements étranges avec SFML ou que vous ayez une suggestion de nouvelle fonctionnalité, vous trouverez de l'aide, des réponses et des conseils sur le forum.
@@ -18,16 +18,16 @@
             Dans le sous-forum <a href="http://fr.sfml-dev.org/forums/index.php?board=24.0" title="Aller au sous-forum 'Projets SFML'">Projets SFML</a> vous trouvez de nombreux projets existant.
         </p>
     </div>
-    <div class="community-column-thin">
+    <div class="stagger-column-thin">
         <a href="http://fr.sfml-dev.org/forums/" title="Aller au forum"><img src="<?php echo image('community/forum.png') ?>" alt="Forum" /></a>
     </div>
 </div>
 
 <div class="home-section">
-    <div class="community-column-thin">
+    <div class="stagger-column-thin">
         <a href="https://github.com/SFML/SFML/wiki" title="Aller au Wiki"><img src="<?php echo image('community/wiki.png') ?>" alt="Wiki" /></a>
     </div>
-    <div class="community-column-wide">
+    <div class="stagger-column-wide">
         <div class="title">&raquo; <a href="https://github.com/SFML/SFML/wiki" title="Aller au Wiki">Wiki</a></div>
         <p>
             Le wiki de la communauté SFML contient des extraits de code, des tutoriels et d'autres contenus issus de la collaboration de la communauté.
@@ -36,7 +36,7 @@
 </div>
 
 <div class="home-section">
-    <div class="community-column-wide">
+    <div class="stagger-column-wide">
         <div class="title">&raquo; <a href="http://chat.sfml-dev.org" title="Chat in the browser now">IRC</a></div>
         <p>
             Pour une aide amicale et des discussions sur SFML (mais aussi des chats hors-sujet, avec un grand nombre d'utilisateurs), cliquez sur le bouton suivant pour discuter instantanément dans votre naviguateur, ou connectez-vous avec votre client IRC favori au serveur décrit ci-dessous.
@@ -47,7 +47,7 @@
             <li><a href="http://chat.sfml-dev.org" title="Discutez dans votre naviguateur maintenant">Discutez dans votre naviguateur maintenant</a></li>
         </ul>
     </div>
-    <div class="community-column-thin">
+    <div class="stagger-column-thin">
         <a href="http://chat.sfml-dev.org"><img src="<?php echo image('community/irc.png') ?>" alt="IRC" /></a>
     </div>
 </div>

--- a/community-fr.php
+++ b/community-fr.php
@@ -9,7 +9,7 @@
 <h1>Communauté</h1>
 
 <div class="home-section">
-    <div class="column">
+    <div class="community-column-wide">
         <div class="title">&raquo; <a href="http://fr.sfml-dev.org/forums/" title="Aller au forum">Forum</a></div>
         <p>
             Que vous ayez une question concernant l'<a href="learn-fr.php" title="Aller à la page des tutoriels et de la documentation">API</a>, que vous rencontriez des comportements étranges avec SFML ou que vous ayez une suggestion de nouvelle fonctionnalité, vous trouverez de l'aide, des réponses et des conseils sur le forum.
@@ -18,16 +18,16 @@
             Dans le sous-forum <a href="http://fr.sfml-dev.org/forums/index.php?board=24.0" title="Aller au sous-forum 'Projets SFML'">Projets SFML</a> vous trouvez de nombreux projets existant.
         </p>
     </div>
-    <div class="column">
+    <div class="community-column-thin">
         <a href="http://fr.sfml-dev.org/forums/" title="Aller au forum"><img src="<?php echo image('community/forum.png') ?>" alt="Forum" /></a>
     </div>
 </div>
 
 <div class="home-section">
-    <div class="column">
+    <div class="community-column-thin">
         <a href="https://github.com/SFML/SFML/wiki" title="Aller au Wiki"><img src="<?php echo image('community/wiki.png') ?>" alt="Wiki" /></a>
     </div>
-    <div class="column">
+    <div class="community-column-wide">
         <div class="title">&raquo; <a href="https://github.com/SFML/SFML/wiki" title="Aller au Wiki">Wiki</a></div>
         <p>
             Le wiki de la communauté SFML contient des extraits de code, des tutoriels et d'autres contenus issus de la collaboration de la communauté.
@@ -36,7 +36,7 @@
 </div>
 
 <div class="home-section">
-    <div class="column">
+    <div class="community-column-wide">
         <div class="title">&raquo; <a href="http://chat.sfml-dev.org" title="Chat in the browser now">IRC</a></div>
         <p>
             Pour une aide amicale et des discussions sur SFML (mais aussi des chats hors-sujet, avec un grand nombre d'utilisateurs), cliquez sur le bouton suivant pour discuter instantanément dans votre naviguateur, ou connectez-vous avec votre client IRC favori au serveur décrit ci-dessous.
@@ -47,7 +47,7 @@
             <li><a href="http://chat.sfml-dev.org" title="Discutez dans votre naviguateur maintenant">Discutez dans votre naviguateur maintenant</a></li>
         </ul>
     </div>
-    <div class="column">
+    <div class="community-column-thin">
         <a href="http://chat.sfml-dev.org"><img src="<?php echo image('community/irc.png') ?>" alt="IRC" /></a>
     </div>
 </div>

--- a/community.php
+++ b/community.php
@@ -9,7 +9,7 @@
 <h1>Community</h1>
 
 <div class="home-section">
-    <div class="column">
+    <div class="community-column-wide">
         <div class="title">&raquo; <a href="http://en.sfml-dev.org/forums/" title="Go to the forum">Forum</a></div>
         <p>
             Whether you have a question about SFML's <a href="learn.php" title="Go to the learn page">API</a>, are experiencing odd behavior with SFML or have a feature request, you'll certainly find help, answers or feedback on the forum.
@@ -18,16 +18,16 @@
             In the <a href="http://en.sfml-dev.org/forums/index.php?board=10.0" title="Go to the 'SFML projects' sub-forum">SFML projects</a> sub-forum you'll find many existing projects.
         </p>
     </div>
-    <div class="column">
+    <div class="community-column-thin">
         <a href="http://en.sfml-dev.org/forums/" title="Go to the forum"><img src="<?php echo image('community/forum.png') ?>" alt="Forum" /></a>
     </div>
 </div>
 
 <div class="home-section">
-    <div class="column">
+    <div class="community-column-thin">
         <a href="https://github.com/SFML/SFML/wiki" title="Go to the wiki"><img src="<?php echo image('community/wiki.png') ?>" alt="Wiki" /></a>
     </div>
-    <div class="column">
+    <div class="community-column-wide">
         <div class="title">&raquo; <a href="https://github.com/SFML/SFML/wiki" title="Go to the wiki">Wiki</a></div>
         <p>
             The SFML community wiki contains code snippets, tutorials and other community-contributed content.
@@ -36,7 +36,7 @@
 </div>
 
 <div class="home-section">
-    <div class="column">
+    <div class="community-column-wide">
         <div class="title">&raquo; <a href="http://chat.sfml-dev.org" title="Chat in the browser now">IRC</a></div>
         <p>
             For friendly help and talk about SFML (as well as off-topic chat with a lot of other users), either click on the button to the right to instantly chat in your browser, or connect via an IRC client to the server below.
@@ -47,7 +47,7 @@
             <li><a href="http://chat.sfml-dev.org" title="Chat in your browser now">Chat in your browser now</a></li>
         </ul>
     </div>
-    <div class="column">
+    <div class="community-column-thin">
         <a href="http://chat.sfml-dev.org"><img src="<?php echo image('community/irc.png') ?>" alt="IRC" /></a>
     </div>
 </div>

--- a/community.php
+++ b/community.php
@@ -9,7 +9,7 @@
 <h1>Community</h1>
 
 <div class="home-section">
-    <div class="community-column-wide">
+    <div class="stagger-column-wide">
         <div class="title">&raquo; <a href="http://en.sfml-dev.org/forums/" title="Go to the forum">Forum</a></div>
         <p>
             Whether you have a question about SFML's <a href="learn.php" title="Go to the learn page">API</a>, are experiencing odd behavior with SFML or have a feature request, you'll certainly find help, answers or feedback on the forum.
@@ -18,16 +18,16 @@
             In the <a href="http://en.sfml-dev.org/forums/index.php?board=10.0" title="Go to the 'SFML projects' sub-forum">SFML projects</a> sub-forum you'll find many existing projects.
         </p>
     </div>
-    <div class="community-column-thin">
+    <div class="stagger-column-thin">
         <a href="http://en.sfml-dev.org/forums/" title="Go to the forum"><img src="<?php echo image('community/forum.png') ?>" alt="Forum" /></a>
     </div>
 </div>
 
 <div class="home-section">
-    <div class="community-column-thin">
+    <div class="stagger-column-thin">
         <a href="https://github.com/SFML/SFML/wiki" title="Go to the wiki"><img src="<?php echo image('community/wiki.png') ?>" alt="Wiki" /></a>
     </div>
-    <div class="community-column-wide">
+    <div class="stagger-column-wide">
         <div class="title">&raquo; <a href="https://github.com/SFML/SFML/wiki" title="Go to the wiki">Wiki</a></div>
         <p>
             The SFML community wiki contains code snippets, tutorials and other community-contributed content.
@@ -36,7 +36,7 @@
 </div>
 
 <div class="home-section">
-    <div class="community-column-wide">
+    <div class="stagger-column-wide">
         <div class="title">&raquo; <a href="http://chat.sfml-dev.org" title="Chat in the browser now">IRC</a></div>
         <p>
             For friendly help and talk about SFML (as well as off-topic chat with a lot of other users), either click on the button to the right to instantly chat in your browser, or connect via an IRC client to the server below.
@@ -47,7 +47,7 @@
             <li><a href="http://chat.sfml-dev.org" title="Chat in your browser now">Chat in your browser now</a></li>
         </ul>
     </div>
-    <div class="community-column-thin">
+    <div class="stagger-column-thin">
         <a href="http://chat.sfml-dev.org"><img src="<?php echo image('community/irc.png') ?>" alt="IRC" /></a>
     </div>
 </div>

--- a/index-fr.php
+++ b/index-fr.php
@@ -19,13 +19,13 @@
             la documentation de l'API</a>.
         </p>
     </div>
-    <div class="column image">
+    <div class="stagger-column-thin">
         <img src="<?php echo image('home/multimedia.png') ?>" alt="Image multimedia" />
     </div>
 </div>
 
 <div class="home-section">
-    <div class="column image">
+    <div class="stagger-column-thin">
         <img src="<?php echo image('home/multiplatform.png') ?>" alt="Image multi-platforme" />
     </div>
     <div class="stagger-column-wide">
@@ -51,7 +51,7 @@
             Apprenez-en d'avantage à leur sujet sur la <a href="download/bindings-fr.php" title="Aller à la page des bindings">page des bindings</a>.
         </p>
     </div>
-    <div class="column image">
+    <div class="stagger-column-thin">
         <img src="<?php echo image('home/multilanguage.png') ?>" alt="Image multi-langage" />
     </div>
 </div>

--- a/index-fr.php
+++ b/index-fr.php
@@ -8,7 +8,7 @@
 <!--div class="news"></div-->
 
 <div class="home-section">
-    <div class="column">
+    <div class="stagger-column-wide">
         <div class="title">SFML est multi-media</div>
         <p>
             SFML offre une interface simple vers les différents composants de votre PC, afin de faciliter le développement de jeux ou d'applications multimedia. Elle se
@@ -28,7 +28,7 @@
     <div class="column image">
         <img src="<?php echo image('home/multiplatform.png') ?>" alt="Image multi-platforme" />
     </div>
-    <div class="column">
+    <div class="stagger-column-wide">
         <div class="title">SFML est multi-plateforme</div>
         <p>
             Avec SFML, votre application peut se compiler et tourner sans effort sur la plupart des systèmes d'exploitation : Windows, Linux, Mac OS X et prochainement
@@ -41,7 +41,7 @@
 </div>
 
 <div class="home-section">
-    <div class="column">
+    <div class="stagger-column-wide">
         <div class="title">SFML est multi-langage</div>
         <p>
             SFML possède des bindings officiels pour les langages C et .Net. Et grace à sa communauté très active, elle est également disponible dans beaucoup d'autres

--- a/index.php
+++ b/index.php
@@ -8,7 +8,7 @@
 <!--div class="news"></div-->
 
 <div class="home-section">
-    <div class="column">
+    <div class="stagger-column-wide">
         <div class="title">SFML is multi-media</div>
         <p>
             SFML provides a simple interface to the various components of your PC, to ease the development of games and multimedia applications. It is composed of
@@ -19,16 +19,16 @@
             the API documentation</a>.
         </p>
     </div>
-    <div class="column">
+    <div class="stagger-column-thin">
         <img src="<?php echo image('home/multimedia.png') ?>" alt="Multimedia image" />
     </div>
 </div>
 
 <div class="home-section">
-    <div class="column">
+    <div class="stagger-column-thin">
         <img src="<?php echo image('home/multiplatform.png') ?>" alt="Multiplatform image" />
     </div>
-    <div class="column">
+    <div class="stagger-column-wide">
         <div class="title">SFML is multi-platform</div>
         <p>
             With SFML, your application can compile and run out of the box on the most common operating systems: Windows, Linux, Mac OS X and soon Android &amp; iOS.
@@ -40,7 +40,7 @@
 </div>
 
 <div class="home-section">
-    <div class="column">
+    <div class="stagger-column-wide">
         <div class="title">SFML is multi-language</div>
         <p>
             SFML has official bindings for the C and .Net languages. And thanks to its active community, it is also available in many other languages such as Java, Ruby,
@@ -50,7 +50,7 @@
             Learn more about them on the <a href="download/bindings.php" title="Go to the bindings page">bindings page</a>.
         </p>
     </div>
-    <div class="column">
+    <div class="stagger-column-thin">
         <img src="<?php echo image('home/multilanguage.png') ?>" alt="Multilanguage image" />
     </div>
 </div>

--- a/styles/style.less
+++ b/styles/style.less
@@ -485,7 +485,7 @@ body
             margin: 0 1%;
         }
         
-        .community-column-wide
+        .stagger-column-wide
         {
             display: inline-block;
             vertical-align: middle;
@@ -493,7 +493,7 @@ body
             margin: 0 1%;
         }
         
-        .community-column-thin
+        .stagger-column-thin
         {
             display: inline-block;
             vertical-align: middle;

--- a/styles/style.less
+++ b/styles/style.less
@@ -484,6 +484,22 @@ body
             width: 45%;
             margin: 0 1%;
         }
+        
+        .community-column-wide
+        {
+            display: inline-block;
+            vertical-align: middle;
+            width: 55%;
+            margin: 0 1%;
+        }
+        
+        .community-column-thin
+        {
+            display: inline-block;
+            vertical-align: middle;
+            width: 35%;
+            margin: 0 1%;
+        }
 
         .title
         {


### PR DESCRIPTION
Modified community page (english and french versions) to use custom style classes that use different widths to stagger the column separation over the rows, as discussed [here](http://en.sfml-dev.org/forums/index.php?topic=20592.0)

