### PR TITLE
Use "std::size_t" instead of "unsigned int" in shapes tutorial since 2.3

### DIFF
--- a/tutorials/2.3/graphics-shape-fr.php
+++ b/tutorials/2.3/graphics-shape-fr.php
@@ -227,12 +227,12 @@ public :
         return m_radius;
     }
 
-    virtual unsigned int getPointCount() const
+    virtual std::size_t getPointCount() const
     {
         return 30; // fixé, mais ça pourrait tout aussi bien être un attribut de la classe
     }
 
-    virtual sf::Vector2f getPoint(unsigned int index) const
+    virtual sf::Vector2f getPoint(std::size_t index) const
     {
         static const float pi = 3.141592654f;
 

--- a/tutorials/2.3/graphics-shape.php
+++ b/tutorials/2.3/graphics-shape.php
@@ -228,12 +228,12 @@ public :
         return m_radius;
     }
 
-    virtual unsigned int getPointCount() const
+    virtual std::size_t getPointCount() const
     {
         return 30; // fixed, but could be an attribute of the class if needed
     }
 
-    virtual sf::Vector2f getPoint(unsigned int index) const
+    virtual sf::Vector2f getPoint(std::size_t index) const
     {
         static const float pi = 3.141592654f;
 

--- a/tutorials/2.4/graphics-shape-fr.php
+++ b/tutorials/2.4/graphics-shape-fr.php
@@ -227,12 +227,12 @@ public :
         return m_radius;
     }
 
-    virtual unsigned int getPointCount() const
+    virtual std::size_t getPointCount() const
     {
         return 30; // fixé, mais ça pourrait tout aussi bien être un attribut de la classe
     }
 
-    virtual sf::Vector2f getPoint(unsigned int index) const
+    virtual sf::Vector2f getPoint(std::size_t index) const
     {
         static const float pi = 3.141592654f;
 

--- a/tutorials/2.4/graphics-shape.php
+++ b/tutorials/2.4/graphics-shape.php
@@ -228,12 +228,12 @@ public :
         return m_radius;
     }
 
-    virtual unsigned int getPointCount() const
+    virtual std::size_t getPointCount() const
     {
         return 30; // fixed, but could be an attribute of the class if needed
     }
 
-    virtual sf::Vector2f getPoint(unsigned int index) const
+    virtual sf::Vector2f getPoint(std::size_t index) const
     {
         static const float pi = 3.141592654f;
 


### PR DESCRIPTION
Since SFML 2.3 `sf::Shape` uses `std::size_t` instead of `unsigned int` for indexing. Fixed for 2.3 and 2.4 tutorials.