### PR TITLE
Add missing underscore in naming convention

### DIFF
--- a/style.php
+++ b/style.php
@@ -254,7 +254,7 @@ Accepted = 202, ///&lt; The request has been accepted, but will be processed lat
   </tr>
   <tr>
    <td>object-style macro (<code>SFML_STATIC</code>)</td>
-   <td>SFML UPPER_CASE (prefixed with SFML)</td>
+   <td>SFML_UPPER_CASE (prefixed with SFML)</td>
   </tr>
  </tbody>
 </table>


### PR DESCRIPTION
Convention column in 'Naming Conventions' acts as an example so make it properly prefixed.