### PR TITLE
Fix missing semicolon in a code sample

### DIFF
--- a/tutorials/2.0/graphics-transform-fr.php
+++ b/tutorials/2.0/graphics-transform-fr.php
@@ -251,7 +251,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // on laisse le noeud se dessiner
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // on dessine ses enfants
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.0/graphics-transform.php
+++ b/tutorials/2.0/graphics-transform.php
@@ -243,7 +243,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // let the node draw itself
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // draw its children
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.1/graphics-transform-fr.php
+++ b/tutorials/2.1/graphics-transform-fr.php
@@ -251,7 +251,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // on laisse le noeud se dessiner
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // on dessine ses enfants
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.1/graphics-transform.php
+++ b/tutorials/2.1/graphics-transform.php
@@ -243,7 +243,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // let the node draw itself
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // draw its children
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.2/graphics-transform-fr.php
+++ b/tutorials/2.2/graphics-transform-fr.php
@@ -251,7 +251,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // on laisse le noeud se dessiner
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // on dessine ses enfants
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.2/graphics-transform.php
+++ b/tutorials/2.2/graphics-transform.php
@@ -243,7 +243,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // let the node draw itself
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // draw its children
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.3/graphics-transform-fr.php
+++ b/tutorials/2.3/graphics-transform-fr.php
@@ -251,7 +251,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // on laisse le noeud se dessiner
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // on dessine ses enfants
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.3/graphics-transform.php
+++ b/tutorials/2.3/graphics-transform.php
@@ -243,7 +243,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // let the node draw itself
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // draw its children
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.4/graphics-transform-fr.php
+++ b/tutorials/2.4/graphics-transform-fr.php
@@ -251,7 +251,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // on laisse le noeud se dessiner
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // on dessine ses enfants
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.4/graphics-transform.php
+++ b/tutorials/2.4/graphics-transform.php
@@ -243,7 +243,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // let the node draw itself
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // draw its children
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.5/graphics-transform-fr.php
+++ b/tutorials/2.5/graphics-transform-fr.php
@@ -251,7 +251,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // on laisse le noeud se dessiner
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // on dessine ses enfants
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)

--- a/tutorials/2.5/graphics-transform.php
+++ b/tutorials/2.5/graphics-transform.php
@@ -243,7 +243,7 @@ public:
         sf::Transform combinedTransform = parentTransform * m_transform;
 
         // let the node draw itself
-        onDraw(target, combinedTransform)
+        onDraw(target, combinedTransform);
 
         // draw its children
         for (std::size_t i = 0; i &lt; m_children.size(); ++i)


### PR DESCRIPTION
Node class code sample was missing semicolon, which caused compilation failure.

I did not create issue for this, since the fix is quite obvious. 