### PR TITLE
sf::Transform tutorial -- clarify transform order

### DIFF
--- a/tutorials/2.5/graphics-transform-fr.php
+++ b/tutorials/2.5/graphics-transform-fr.php
@@ -165,7 +165,7 @@ sf::Transform t3(2.f, 0.f, 20.f,
 sf::Transform t4 = t1 * t2 * t3;
 </code></pre>
 <p>
-    Vous pouvez bien entendu appliquer plusieurs transformations de base au même <?php class_link('Transform') ?>, celles-ci seront toutes combinées séquentiellement :
+    Vous pouvez bien entendu appliquer plusieurs transformations de base au même <?php class_link('Transform') ?>, celles-ci seront toutes combinées séquentiellement. Remarquez que transformer un objet en combinant plusieurs transformations est équivalent à effectuer chaque opération dans l'ordre inverse. La dernière opération (ici <code>scale</code>) est appliquée en premier, et sera affectée par les opérations en amont dans le code (la deuxième serait <code>translate(-10.f, 50.f)</code>, par exemple).
 </p>
 <pre><code class="cpp">sf::Transform t;
 t.translate(10.f, 100.f);

--- a/tutorials/2.5/graphics-transform.php
+++ b/tutorials/2.5/graphics-transform.php
@@ -160,7 +160,7 @@ sf::Transform t3(2.f, 0.f, 20.f,
 sf::Transform t4 = t1 * t2 * t3;
 </code></pre>
 <p>
-    You can apply several predefined transformations to the same transform as well. They will all be combined sequentially:
+    You can apply several predefined transformations to the same transform as well. They will all be combined sequentially. Note that transforming an object by combining multiple transformations is equivalent to applying each operation in reverse order. The last operation (here <code>scale</code>) is applied first, and will be affected by operations above it in code (second would be <code>translate(-10.f, 50.f)</code>, for example).
 </p>
 <pre><code class="cpp">sf::Transform t;
 t.translate(10.f, 100.f);


### PR DESCRIPTION
Clarify order of transforms, as highlighted by pvigier in https://github.com/SFML/SFML/issues/1608.

Once people agree with the wording, we can backport it to older tutorials.