### PR TITLE
Fix typo

### DIFF
--- a/tutorials/2.5/compile-with-cmake-fr.php
+++ b/tutorials/2.5/compile-with-cmake-fr.php
@@ -260,7 +260,7 @@
             </td>
         </tr>
         <tr class="one">
-            <td><code>SFML_USE_SYSTEM_DEP</code></td>
+            <td><code>SFML_USE_SYSTEM_DEPS</code></td>
             <td>
                 Cette option booléenne détermine si ce sont les dépendances du répertoire "extlibs" qui sont utilisées, ou les dépendances trouvées sur le système.<br/>
                 Les en-têtes stb_image_* du répertoire "extlibs" sont toujours utilisés indépendamment de cette option.

--- a/tutorials/2.5/compile-with-cmake.php
+++ b/tutorials/2.5/compile-with-cmake.php
@@ -253,7 +253,7 @@
             </td>
         </tr>
         <tr class="one">
-            <td><code>SFML_USE_SYSTEM_DEP</code></td>
+            <td><code>SFML_USE_SYSTEM_DEPS</code></td>
             <td>
                 This boolean option controls whether the dependencies from the extlibs directory are used or whether the system dependencies are used.<br/>
                 The stb_image_* header in the extlibs directory are used regardless of this option.


### PR DESCRIPTION
Fix typo concerning the `cmake` option (see https://github.com/SFML/SFML/blob/master/CMakeLists.txt#L169)