### PR TITLE
Replace non-breaking hyphen with ascii hyphen

### DIFF
--- a/tutorials/2.0/compile-with-cmake-fr.php
+++ b/tutorials/2.0/compile-with-cmake-fr.php
@@ -331,13 +331,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Construit la bibliothèque SFML correspondante. La cible "sfml-main" n'est disponible que sous Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Construit l'exemple SFML correspondant. Ces cibles ne sont disponibles que si l'option <code>SFML_BUILD_EXAMPLES</code> a été activée. Notez que certains
                 exemples ne sont définis que pour un OS particulier ("cocoa" n'est disponible que sous Mac OS X, "win32" sous Windows, "X11" sous Linux, etc.).

--- a/tutorials/2.0/compile-with-cmake.php
+++ b/tutorials/2.0/compile-with-cmake.php
@@ -322,13 +322,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Builds the corresponding SFML library. The "sfml-main" target is available only when building for Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Builds the corresponding SFML example. These targets are available only if the <code>SFML_BUILD_EXAMPLES</code> option is enabled. Note that some of the
                 targets are available only on certain operating systems ("cocoa" is available on Mac OS X, "win32" on Windows, "X11" on Linux, etc.).

--- a/tutorials/2.1/compile-with-cmake-fr.php
+++ b/tutorials/2.1/compile-with-cmake-fr.php
@@ -331,13 +331,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Construit la bibliothèque SFML correspondante. La cible "sfml-main" n'est disponible que sous Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Construit l'exemple SFML correspondant. Ces cibles ne sont disponibles que si l'option <code>SFML_BUILD_EXAMPLES</code> a été activée. Notez que certains
                 exemples ne sont définis que pour un OS particulier ("cocoa" n'est disponible que sous Mac OS X, "win32" sous Windows, "X11" sous Linux, etc.).

--- a/tutorials/2.1/compile-with-cmake.php
+++ b/tutorials/2.1/compile-with-cmake.php
@@ -322,13 +322,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Builds the corresponding SFML library. The "sfml-main" target is available only when building for Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Builds the corresponding SFML example. These targets are available only if the <code>SFML_BUILD_EXAMPLES</code> option is enabled. Note that some of the
                 targets are available only on certain operating systems ("cocoa" is available on Mac OS X, "win32" on Windows, "X11" on Linux, etc.).

--- a/tutorials/2.2/compile-with-cmake-fr.php
+++ b/tutorials/2.2/compile-with-cmake-fr.php
@@ -333,13 +333,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Construit la bibliothèque SFML correspondante. La cible "sfml-main" n'est disponible que sous Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Construit l'exemple SFML correspondant. Ces cibles ne sont disponibles que si l'option <code>SFML_BUILD_EXAMPLES</code> a été activée. Notez que certains
                 exemples ne sont définis que pour un OS particulier ("cocoa" n'est disponible que sous Mac OS X, "win32" sous Windows, "X11" sous Linux, etc.).

--- a/tutorials/2.2/compile-with-cmake.php
+++ b/tutorials/2.2/compile-with-cmake.php
@@ -324,13 +324,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Builds the corresponding SFML library. The "sfml-main" target is available only when building for Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Builds the corresponding SFML example. These targets are available only if the <code>SFML_BUILD_EXAMPLES</code> option is enabled. Note that some of the
                 targets are available only on certain operating systems ("cocoa" is available on Mac OS X, "win32" on Windows, "X11" on Linux, etc.).

--- a/tutorials/2.3/compile-with-cmake-fr.php
+++ b/tutorials/2.3/compile-with-cmake-fr.php
@@ -339,13 +339,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Construit la bibliothèque SFML correspondante. La cible "sfml-main" n'est disponible que sous Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Construit l'exemple SFML correspondant. Ces cibles ne sont disponibles que si l'option <code>SFML_BUILD_EXAMPLES</code> a été activée. Notez que certains
                 exemples ne sont définis que pour un OS particulier ("cocoa" n'est disponible que sous Mac OS X, "win32" sous Windows, "X11" sous Linux, etc.).

--- a/tutorials/2.3/compile-with-cmake.php
+++ b/tutorials/2.3/compile-with-cmake.php
@@ -330,13 +330,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Builds the corresponding SFML library. The "sfml-main" target is available only when building for Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Builds the corresponding SFML example. These targets are available only if the <code>SFML_BUILD_EXAMPLES</code> option is enabled. Note that some of the
                 targets are available only on certain operating systems ("cocoa" is available on Mac OS X, "win32" on Windows, "X11" on Linux, etc.).

--- a/tutorials/2.4/compile-with-cmake-fr.php
+++ b/tutorials/2.4/compile-with-cmake-fr.php
@@ -341,13 +341,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Construit la bibliothèque SFML correspondante. La cible "sfml-main" n'est disponible que sous Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Construit l'exemple SFML correspondant. Ces cibles ne sont disponibles que si l'option <code>SFML_BUILD_EXAMPLES</code> a été activée. Notez que certains
                 exemples ne sont définis que pour un OS particulier ("cocoa" n'est disponible que sous macOS, "win32" sous Windows, "X11" sous Linux, etc.).

--- a/tutorials/2.4/compile-with-cmake.php
+++ b/tutorials/2.4/compile-with-cmake.php
@@ -331,13 +331,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Builds the corresponding SFML library. The "sfml-main" target is available only when building for Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Builds the corresponding SFML example. These targets are available only if the <code>SFML_BUILD_EXAMPLES</code> option is enabled. Note that some of the
                 targets are available only on certain operating systems ("cocoa" is available on macOS, "win32" on Windows, "X11" on Linux, etc.).

--- a/tutorials/2.5/compile-with-cmake-fr.php
+++ b/tutorials/2.5/compile-with-cmake-fr.php
@@ -375,13 +375,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Construit la bibliothèque SFML correspondante. La cible "sfml-main" n'est disponible que sous Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Construit l'exemple SFML correspondant. Ces cibles ne sont disponibles que si l'option <code>SFML_BUILD_EXAMPLES</code> a été activée. Notez que certains
                 exemples ne sont définis que pour un OS particulier ("cocoa" n'est disponible que sous macOS, "win32" sous Windows, "X11" sous Linux, etc.).

--- a/tutorials/2.5/compile-with-cmake.php
+++ b/tutorials/2.5/compile-with-cmake.php
@@ -352,13 +352,13 @@
             </td>
         </tr>
         <tr class="two">
-            <td><code>sfml&#8209;system<br/>sfml&#8209;window<br/>sfml&#8209;network<br/>sfml&#8209;graphics<br/>sfml&#8209;audio<br/>sfml&#8209;main</code></td>
+            <td><code>sfml-system<br/>sfml-window<br/>sfml-network<br/>sfml-graphics<br/>sfml-audio<br/>sfml-main</code></td>
             <td>
                 Builds the corresponding SFML library. The "sfml-main" target is available only when building for Windows.
             </td>
         </tr>
         <tr class="one">
-            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound&#8209;capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
+            <td><code>cocoa<br/>ftp<br/>opengl<br/>pong<br/>shader<br/>sockets<br/>sound<br/>sound-capture<br/>voip<br/>window<br/>win32<br/>X11</code></td>
             <td>
                 Builds the corresponding SFML example. These targets are available only if the <code>SFML_BUILD_EXAMPLES</code> option is enabled. Note that some of the
                 targets are available only on certain operating systems ("cocoa" is available on macOS, "win32" on Windows, "X11" on Linux, etc.).


### PR DESCRIPTION
Fix #155 
Replacing `&#8209;` unicode character with a regular `-` so anyone can copy-paste it directly