### PR TITLE
Update rust-sfml versioning

### DIFF
--- a/download/bindings-fr.php
+++ b/download/bindings-fr.php
@@ -169,7 +169,7 @@
         <tr>
             <th rowspan="1">Rust</th>
             <td><a href="https://github.com/jeremyletang/rust-sfml" class="website"><img src="../images/bindings/rust-sfml.png" alt="rust-sfml"></a></td>
-            <td>2.5</td>
+            <td>2.5.1</td>
             <td><a href="mailto:letang.jeremy@gmail.com">Jérémy Letang</a></td>
         </tr>
         <tr>

--- a/download/bindings.php
+++ b/download/bindings.php
@@ -169,7 +169,7 @@
         <tr>
             <th rowspan="1">Rust</th>
             <td><a href="https://github.com/jeremyletang/rust-sfml" class="website"><img src="../images/bindings/rust-sfml.png" alt="rust-sfml"></a></td>
-            <td>2.5</td>
+            <td>2.5.1</td>
             <td><a href="mailto:letang.jeremy@gmail.com">Jérémy Letang</a></td>
         </tr>
         <tr>


### PR DESCRIPTION
Rust-sfml uses 2.5.1. It's been like that for a while, just no one updated the bindings page.