### PR TITLE
Add tutorial page for CMake template

### DIFF
--- a/tutorials/2.6/index-fr.php
+++ b/tutorials/2.6/index-fr.php
@@ -8,6 +8,7 @@
 
 <?php h2('Démarrer') ?>
 <ul>
+    <li><a href="./start-cmake-fr.php" title="SFML avec le modèle de projet CMake">SFML avec le modèle de projet CMake</a></li>
     <li><a href="./start-vc-fr.php" title="SFML et Visual Studio">SFML et Visual Studio</a></li>
     <li><a href="./start-cb-fr.php" title="SFML et Code::Blocks">SFML et Code::Blocks (MinGW)</a></li>
     <li><a href="./start-linux-fr.php" title="SFML et Linux">SFML et Linux</a></li>
@@ -39,7 +40,7 @@
     <li><a href="graphics-vertex-array-fr.php" title="Concevoir ses entités avec les tableaux de vertex">Concevoir ses entités avec les tableaux de vertex</a></li>
     <li><a href="graphics-transform-fr.php" title="Position, rotation, échelle : transformer des entités">Position, rotation, échelle : transformer des entités</a></li>
     <li><a href="graphics-shader-fr.php" title="Effets spéciaux avec les shaders">Effets spéciaux avec les shaders</a></li>
-    <li><a href="graphics-view-fr.php" title="CContrôler la caméra 2D avec les vues">Contrôler la caméra 2D avec les vues</a></li>
+    <li><a href="graphics-view-fr.php" title="Contrôler la caméra 2D avec les vues">Contrôler la caméra 2D avec les vues</a></li>
 </ul>
 
 <?php h2('Module audio') ?>

--- a/tutorials/2.6/index.php
+++ b/tutorials/2.6/index.php
@@ -8,6 +8,7 @@
 
 <?php h2('Getting started') ?>
 <ul>
+    <li><a href="start-cmake.php" title="SFML with CMake Project Template">SFML with CMake Project Template</a></li>
     <li><a href="start-vc.php" title="SFML and Visual Studio">SFML and Visual Studio</a></li>
     <li><a href="start-cb.php" title="SFML and Code::Blocks">SFML and Code::Blocks (MinGW)</a></li>
     <li><a href="start-linux.php" title="SFML and Linux">SFML and Linux</a></li>

--- a/tutorials/2.6/index.php
+++ b/tutorials/2.6/index.php
@@ -1,14 +1,14 @@
 <?php
-    $page = 'index.php';
-    $title = '';
-    require("header.php");
+$page = 'index.php';
+$title = '';
+require("header.php");
 ?>
 
 <h1>Tutorials for SFML <?php echo $version; ?></h1>
 
 <?php h2('Getting started') ?>
 <ul>
-    <li><a href="start-cmake.php" title="SFML with CMake Project Template">SFML with CMake Project Template</a></li>
+    <li><a href="start-cmake.php" title="SFML with the CMake Project Template">SFML with the CMake Project Template</a></li>
     <li><a href="start-vc.php" title="SFML and Visual Studio">SFML and Visual Studio</a></li>
     <li><a href="start-cb.php" title="SFML and Code::Blocks">SFML and Code::Blocks (MinGW)</a></li>
     <li><a href="start-linux.php" title="SFML and Linux">SFML and Linux</a></li>
@@ -61,6 +61,6 @@
 
 <?php
 
-    require("footer.php");
+require("footer.php");
 
 ?>

--- a/tutorials/2.6/index.php
+++ b/tutorials/2.6/index.php
@@ -1,7 +1,7 @@
 <?php
-$page = 'index.php';
-$title = '';
-require("header.php");
+    $page = 'index.php';
+    $title = '';
+    require("header.php");
 ?>
 
 <h1>Tutorials for SFML <?php echo $version; ?></h1>
@@ -61,6 +61,6 @@ require("header.php");
 
 <?php
 
-require("footer.php");
+    require("footer.php");
 
 ?>

--- a/tutorials/2.6/start-cmake-fr.php
+++ b/tutorials/2.6/start-cmake-fr.php
@@ -1,0 +1,113 @@
+<?php
+
+    $title = "SFML avec le modèle de projet CMake";
+    $page = "start-cmake-fr.php";
+
+    require("header-fr.php");
+
+?>
+
+<h1>SFML avec le modèle de projet CMake</h1>
+
+<?php h2('Introduction') ?>
+<p>
+    Ce tutoriel fonctionnera sur n'importe quel système d'exploitation, avec n'importe quel environnement de développement intégré (IDE) et n'importe quel compilateur.
+    Il expliquera comment créer un projet pouvant être utilisé avec n'importe quelle version, branche ou commit Git de SFML.
+    Cette approche est unique en ce sens qu'elle élimine la possibilité d'erreurs de liaison et facilite autant que possible la mise à niveau de votre version de SFML à l'avenir.
+    Elle inclut même un pipeline d'intégration continue (CI) pour vérifier automatiquement que votre projet continue de se compiler sur Windows, Linux et macOS.
+</p>
+
+<?php h2('Créez votre propre projet GitHub') ?>
+<p>
+    <a class="external" title="Modèle de projet CMake SFML repository" href="https://github.com/SFML/cmake-sfml-project">https://github.com/SFML/cmake-sfml-project</a>
+</p>
+<p>
+    Le dépôt GitHub ci-dessus est ce que GitHub appelle un
+    <a class="external" title="Documentation GitHub sur les modèles de dépôt" href="https://docs.github.com/fr/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template">modèle (template) de dépôt</a>.
+    Consultez la documentation de GitHub sur les modèles de dépôt pour créer votre propre projet GitHub à partir de ce modèle.
+    Cette étape garantit que votre code est conservé en sécurité dans un emplacement distant, pour éviter toute perte accidentelle.
+</p>
+
+<?php h2('Personnalisez le projet CMake et les noms exécutables') ?>
+<p>
+    Par défaut, ce projet utilise des noms de remplacement pour le nom du projet et le nom exécutable.
+    Ces noms peuvent être ce que vous voulez et n'ont pas besoin d'être identiques.
+    Le nom du projet est défini dans l'appel à <code>project()</code> en haut de <code>CMakeLists.txt</code>.
+</p>
+<p>
+    Le nom exécutable est défini dans l'appel à <code>add_executable()</code>.
+    Assurez-vous de remplacer toutes les occurrences de l'ancien nom exécutable.
+    Le nom exécutable est utilisé plusieurs fois après la création de l'exécutable.
+</p>
+
+<?php h2('Ajoutez vos propres fichiers source') ?>
+<p>
+    Le seul fichier C++ dans le projet au départ est <code>src/main.cpp</code>.
+    Vous pouvez renommer, supprimer ou ajouter des fichiers source selon les besoins de votre propre projet.
+    Assurez-vous simplement que tous les fichiers <code>.cpp</code> sont inclus dans l'appel à <code>add_executable</code> pour éviter les erreurs de liaison (link).
+</p>
+
+<?php h2('Conditions requises') ?>
+<p>
+    Étant donné que ce modèle construit SFML à partir des sources, les utilisateurs de Linux devront d'abord installer les paquets système requis.
+    Sur Ubuntu ou d'autres systèmes d'exploitation basés sur Debian, cela peut être fait avec les commandes ci-dessous.
+    Un processus similaire sera nécessaire pour les distributions Linux non basées sur Debian, comme Fedora.
+</p>
+<pre>
+    <code class="no-highlight">
+    sudo apt update
+    sudo apt install \
+        libxrandr-dev \
+        libxcursor-dev \
+        libudev-dev \
+        libopenal-dev \
+        libflac-dev \
+        libvorbis-dev \
+        libgl1-mesa-dev \
+        libegl1-mesa-dev \
+        libdrm-dev \
+        libgbm-dev
+    </code>
+</pre>
+<p>
+    Le modèle CMake nécessite l'installation de CMake.
+    Le gestionnaire de paquets de votre système est le meilleur moyen d'obtenir CMake.
+    Il est également installé avec Visual Studio.
+    Si, pour une raison quelconque, les options précédentes ne fonctionnent pas, vous pouvez utiliser
+    <a class="external" title="Téléchargement de CMake" href="https://cmake.org/download/">https://cmake.org/download/</a>
+    pour installer CMake sur votre système d'exploitation.
+</p>
+<p>
+    <a class="external" title="Git SCM" href="https://git-scm.com/">Git</a> est également nécessaire car CMake utilise Git pour cloner le dépôt SFML.
+    Si vous avez cloné votre propre projet GitHub, vous avez déjà Git installé.
+    Sans Git, CMake échouera de manière peu intuitive.
+</p>
+
+<?php h2('Configurez et construisez votre projet') ?>
+<p>
+    Maintenant que vous avez apporté toutes les modifications souhaitées au script de construction, nous sommes prêts à construire !
+    CMake est de loin le système de construction C++ le plus populaire, de sorte que n'importe quel environnement de développement intégré (IDE) que vous utilisez prendra en charge les projets CMake.
+    Ci-dessous, quelques liens vers la documentation pour la configuration de projets CMake avec quelques IDE populaires différents.
+</p>
+<ul>
+    <li><a class="external" title="Documentation du projet CMake pour VS Code" href="https://code.visualstudio.com/docs/cpp/cmake-linux">VS Code</a></li>
+    <li><a class="external" title="Documentation du projet CMake pour Visual Studio" href="https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170">Visual Studio</a></li>
+    <li><a class="external" title="Documentation du projet CMake pour CLion" href="https://www.jetbrains.com/clion/features/cmake-support.html">CLion</a></li>
+    <li><a class="external" title="Documentation du projet CMake pour Qt Creator" href="https://doc.qt.io/qtcreator/creator-project-cmake.html">Qt Creator</a></li>
+</ul>
+<p>
+    Si vous préférez construire ce projet depuis la ligne de commande au lieu de passer par votre IDE, c'est également facile à faire.
+    Vous pouvez utiliser ces deux commandes shell pour effectuer une compilation de version.
+</p>
+<pre>
+    <code class="no-highlight">
+    cmake -B build -DCMAKE_BUILD_TYPE=Release
+    cmake --build build --config Release
+    </code>
+</pre>
+
+<?php
+
+    require("footer-fr.php");
+
+?>

--- a/tutorials/2.6/start-cmake.php
+++ b/tutorials/2.6/start-cmake.php
@@ -1,0 +1,113 @@
+<?php
+
+    $title = "SFML with CMake Project Template";
+    $page = "start-cmake.php";
+
+    require("header.php");
+
+?>
+
+<h1>SFML with CMake Project Template</h1>
+
+<?php h2('Introduction') ?>
+<p>
+    This tutorial will work on any OS, with any IDE, and with any compiler.
+    It will explain how to build a project that can be used with any release, branch, or Git commit of SFML.
+    This approach is unique in that it eliminates the possibility of linker errors and makes it as easy as possible to upgrade your SFML version in the future.
+    It even includes a CI pipeline to automatically verify that your project continues to compile on Windows, Linux, and macOS.
+</p>
+
+<?php h2('Create Your Own GitHub Project') ?>
+<p>
+    <a class="external" title="CMake sfml project repository" href="https://github.com/SFML/cmake-sfml-project">https://github.com/SFML/cmake-sfml-project</a>
+</p>
+<p>
+    The GitHub repository above is what GitHub calls a
+    <a class="external" title="GitHub documentation about repository templates" href="https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template">repository template</a>.
+    Check out GitHub's documentation on repository templates to make your own GitHub project out of this template.
+    This step ensures your code is kept safe in a remote location so you won't accidentally lose it.
+</p>
+
+<?php h2('Customize CMake Project and Executable Names') ?>
+<p>
+    Out of the box this project uses placeholder names for the project name and executable name.
+    These names can be whatever you'd like and do not have to match.
+    The project name is defined in the call to <code>project()</code> at the top of CMakeLists.txt.
+</p>
+<p>
+    The executable name is defined in the call to <code>add_executable()</code>.
+    Be sure to replace all instances of that old executable name.
+    The executable name is used a few more times after the executable is made.
+</p>
+
+<?php h2('Add Your Own Source Files') ?>
+<p>
+    The only C++ file in the project to begin with is src/main.cpp.
+    You may rename, remove, or add source files as needed for your own project.
+    Just be sure that all .cpp files are included in the <code>add_executable</code> call to avoid linker errors.
+</p>
+
+<?php h2('Requirements') ?>
+<p>
+    Because this template builds SFML from source, Linux users will need to install the required system packages first.
+    On Ubuntu or other Debian-based OSes, that can be done with the commands below.
+    A similar process will be required for non-Debian Linux distributions like Fedora.
+</p>
+<pre>
+    <code class="no-highlight">
+    sudo apt update
+    sudo apt install \
+        libxrandr-dev \
+        libxcursor-dev \
+        libudev-dev \
+        libopenal-dev \
+        libflac-dev \
+        libvorbis-dev \
+        libgl1-mesa-dev \
+        libegl1-mesa-dev \
+        libdrm-dev \
+        libgbm-dev
+    </code>
+</pre>
+<p>
+    The CMake template requires having CMake installed.
+    Your system's package manager is the best way to get CMake.
+    It also gets installed alongside Visual Studio.
+    If for some reason the previous options will not work, you can use
+    <a class="external" title="CMake download" href="https://cmake.org/download/">https://cmake.org/download/</a>
+    to install CMake for your operating system.
+</p>
+<p>
+    Git is also required since CMake uses Git to clone the SFML repository.
+    If you cloned your own GitHub project then you will already have Git installed.
+    Without Git CMake will fail in an unintuitive way.
+</p>
+
+<?php h2('Configure and Build Your Project') ?>
+<p>
+    Now that you've made any changes you'd like to the build script, we're ready to build!
+    CMake is by far the most popular C++ build system so any IDE you may use will have support for CMake project.
+    Below are some links to the documentation for setting up CMake project with a few different popular IDEs.
+</p>
+<ul>
+    <li><a class="external" title="VS Code CMake project documentation" href="https://code.visualstudio.com/docs/cpp/cmake-linux">VS Code</a></li>
+    <li><a class="external" title="Visual Studio CMake project documentation" href="https://docs.microsoft.com/en-us/cpp/build/cmake-projects-in-visual-studio?view=msvc-170">Visual Studio</a></li>
+    <li><a class="external" title="CLion CMake project documentation" href="https://www.jetbrains.com/clion/features/cmake-support.html">CLion</a></li>
+    <li><a class="external" title="Qt Creator CMake project documentation" href="https://doc.qt.io/qtcreator/creator-project-cmake.html">Qt Creator</a></li>
+</ul>
+<p>
+    If you would rather build this project from the command line instead of via your IDE that's easy to do as well.
+    You can use these two shell commands to do a release build of the project.
+</p>
+<pre>
+    <code class="no-highlight">
+    cmake -B build -DCMAKE_BUILD_TYPE=Release
+    cmake --build build --config Release
+    </code>
+</pre>
+
+<?php
+
+    require("footer.php");
+
+?>

--- a/tutorials/2.6/start-cmake.php
+++ b/tutorials/2.6/start-cmake.php
@@ -1,9 +1,9 @@
 <?php
 
-$title = "SFML with the CMake Project Template";
-$page = "start-cmake.php";
+    $title = "SFML with the CMake Project Template";
+    $page = "start-cmake.php";
 
-require("header.php");
+    require("header.php");
 
 ?>
 
@@ -104,6 +104,6 @@ cmake --build build --config Release</code>
 
 <?php
 
-require("footer.php");
+    require("footer.php");
 
 ?>

--- a/tutorials/2.6/start-cmake.php
+++ b/tutorials/2.6/start-cmake.php
@@ -1,38 +1,38 @@
 <?php
 
-    $title = "SFML with CMake Project Template";
-    $page = "start-cmake.php";
+$title = "SFML with the CMake Project Template";
+$page = "start-cmake.php";
 
-    require("header.php");
+require("header.php");
 
 ?>
 
-<h1>SFML with CMake Project Template</h1>
+<h1>SFML with the CMake Project Template</h1>
 
 <?php h2('Introduction') ?>
 <p>
     This tutorial will work on any OS, with any IDE, and with any compiler.
-    It will explain how to build a project that can be used with any release, branch, or Git commit of SFML.
-    This approach is unique in that it eliminates the possibility of linker errors and makes it as easy as possible to upgrade your SFML version in the future.
-    It even includes a CI pipeline to automatically verify that your project continues to compile on Windows, Linux, and macOS.
+    It will explain, how to build a project, that can be used with any release, branch, or Git commit of SFML.
+    This approach is unique, in that it eliminates the possibility of linker errors and makes it as easy as possible to upgrade your SFML version in the future.
+    It even includes a CI pipeline to automatically verify, that your project continues to compile on Windows, Linux, and macOS.
 </p>
 
 <?php h2('Create Your Own GitHub Project') ?>
 <p>
-    <a class="external" title="CMake sfml project repository" href="https://github.com/SFML/cmake-sfml-project">https://github.com/SFML/cmake-sfml-project</a>
+    <a class="external" title="CMake SFML Project Template Repository" href="https://github.com/SFML/cmake-sfml-project">https://github.com/SFML/cmake-sfml-project</a>
 </p>
 <p>
     The GitHub repository above is what GitHub calls a
     <a class="external" title="GitHub documentation about repository templates" href="https://docs.github.com/en/repositories/creating-and-managing-repositories/creating-a-repository-from-a-template">repository template</a>.
     Check out GitHub's documentation on repository templates to make your own GitHub project out of this template.
-    This step ensures your code is kept safe in a remote location so you won't accidentally lose it.
+    This step ensures your code is kept safe in a remote location, so you won't accidentally lose it.
 </p>
 
-<?php h2('Customize CMake Project and Executable Names') ?>
+<?php h2('Customize the CMake Project and Executable Names') ?>
 <p>
     Out of the box this project uses placeholder names for the project name and executable name.
     These names can be whatever you'd like and do not have to match.
-    The project name is defined in the call to <code>project()</code> at the top of CMakeLists.txt.
+    The project name is defined in the call to <code>project()</code> at the top of <code>CMakeLists.txt</code>.
 </p>
 <p>
     The executable name is defined in the call to <code>add_executable()</code>.
@@ -42,9 +42,9 @@
 
 <?php h2('Add Your Own Source Files') ?>
 <p>
-    The only C++ file in the project to begin with is src/main.cpp.
+    The only C++ file in the project to begin with is <code>src/main.cpp</code>.
     You may rename, remove, or add source files as needed for your own project.
-    Just be sure that all .cpp files are included in the <code>add_executable</code> call to avoid linker errors.
+    Just be sure that all <code>.cpp</code> files are included in the <code>add_executable</code> call to avoid linker errors.
 </p>
 
 <?php h2('Requirements') ?>
@@ -54,20 +54,18 @@
     A similar process will be required for non-Debian Linux distributions like Fedora.
 </p>
 <pre>
-    <code class="no-highlight">
-    sudo apt update
-    sudo apt install \
-        libxrandr-dev \
-        libxcursor-dev \
-        libudev-dev \
-        libopenal-dev \
-        libflac-dev \
-        libvorbis-dev \
-        libgl1-mesa-dev \
-        libegl1-mesa-dev \
-        libdrm-dev \
-        libgbm-dev
-    </code>
+    <code class="no-highlight">sudo apt update
+sudo apt install \
+    libxrandr-dev \
+    libxcursor-dev \
+    libudev-dev \
+    libopenal-dev \
+    libflac-dev \
+    libvorbis-dev \
+    libgl1-mesa-dev \
+    libegl1-mesa-dev \
+    libdrm-dev \
+    libgbm-dev</code>
 </pre>
 <p>
     The CMake template requires having CMake installed.
@@ -78,16 +76,16 @@
     to install CMake for your operating system.
 </p>
 <p>
-    Git is also required since CMake uses Git to clone the SFML repository.
-    If you cloned your own GitHub project then you will already have Git installed.
-    Without Git CMake will fail in an unintuitive way.
+    <a class="external" title="Git SCM" href="https://git-scm.com/">Git</a> is also required since CMake uses Git to clone the SFML repository.
+    If you cloned your own GitHub project, then you will already have Git installed.
+    Without Git, CMake will fail in an unintuitive way.
 </p>
 
 <?php h2('Configure and Build Your Project') ?>
 <p>
-    Now that you've made any changes you'd like to the build script, we're ready to build!
-    CMake is by far the most popular C++ build system so any IDE you may use will have support for CMake project.
-    Below are some links to the documentation for setting up CMake project with a few different popular IDEs.
+    Now that you've made any changes you wanted to the build script, we're ready to build!
+    CMake is by far the most popular C++ build system so any IDE you may use, will have support for CMake projects.
+    Below are some links to the documentation for setting up CMake projects with a few different popular IDEs.
 </p>
 <ul>
     <li><a class="external" title="VS Code CMake project documentation" href="https://code.visualstudio.com/docs/cpp/cmake-linux">VS Code</a></li>
@@ -96,18 +94,16 @@
     <li><a class="external" title="Qt Creator CMake project documentation" href="https://doc.qt.io/qtcreator/creator-project-cmake.html">Qt Creator</a></li>
 </ul>
 <p>
-    If you would rather build this project from the command line instead of via your IDE that's easy to do as well.
+    If you would rather build this project from the command line instead of via your IDE, that's easy to do as well.
     You can use these two shell commands to do a release build of the project.
 </p>
 <pre>
-    <code class="no-highlight">
-    cmake -B build -DCMAKE_BUILD_TYPE=Release
-    cmake --build build --config Release
-    </code>
+    <code class="no-highlight">cmake -B build -DCMAKE_BUILD_TYPE=Release
+cmake --build build --config Release</code>
 </pre>
 
 <?php
 
-    require("footer.php");
+require("footer.php");
 
 ?>


### PR DESCRIPTION
I have no idea how to write PHP, HTML, or do any web development nor do I know how to build these docs to view them locally so bear with me if I did a poor job. I'm mostly copy-pasting from other files that seem to do the thing I want to do.

I ended up repeating most of what is already in the CMake template project's README. I still think we'd be better off simply linking to that project instead of rewriting that project's README into a different language and having to maintain both.