### PR TITLE
Feature/update tutorial about threads

### DIFF
--- a/faq.php
+++ b/faq.php
@@ -75,6 +75,7 @@ include('header.php');
         <li><a href="#system-mutex">How do I use sf::Mutex?</a></li>
         <li><a href="#system-thread-container">Why can't I store my sf::Thread in an STL container?</a></li>
         <li><a href="#system-sleep">Why doesn't sf::sleep sleep for the amount of time I want it to?</a></li>
+        <li><a href="#system-thread-safe">Is SFML thread-safe?</a></li>
     </ul>
 
     <p><strong><a href="#programming">Programming in General</a></strong></p>
@@ -587,6 +588,10 @@ std::size_t pos = cpp_string.find( sfml_string );</code></pre>
     <p>In recent revisions of SFML, the timer resolution is temporarily increased during a call to <code>sf::sleep()</code> to increase the likelihood of your sf::sleep call sleeping for the correct amount of time.</p>
     <p>One thing to remember is that although the operating system marks your thread as "awake" after it is done sleeping, even for exactly the correct duration, it doesn't mean it resumes execution immediately. It could have just missed the moment at which the scheduler selects which task to execute next and thus must wait for the next transition. In this case, although your thread slept for the correct amount, it will appear to you as if it slept for more. SFML doesn't allow you to sleep for 0 duration, however if you could, you would notice that it in fact takes a slight bit of time as well. This is because it is common for specifying 0 to the operating system to translate to simply yielding your execution time slice to another thread.</p>
     <p>In the end, what this means is that <code>sf::sleep()</code> is merely a guideline, and not a contract. The longer you sleep for, the more accurate it will be. The shorter you sleep for, the less accurate it will be and to a certain extent more dependent on luck it will become.</p>
+
+    <h3 id="system-thread-safe"><a class="h3-link" href="#system-thread-safe">Is SFML thread-safe?</a><a class="back-to-top" href="#top" title="Top of the page"></a></h3>
+    <p>No, instances of SFML's classes are not thread-safe by themselves. If you need thread-safety you must protect them. SFML comes with <a href="/documentation/latest/classsf_1_1Mutex.php"><code>sf::Mutex</code></a> and <a href="/documentation/latest/classsf_1_1Lock.php"><code>sf::Lock</code></a> for this purpose but you can use other tools you may have available such as C++11's <code>std::mutex</code> and <code>std::lock_guard</code> as you see fit.</p>
+    <p>For more information on how to protect you shared data, refer to the <a href="/tutorials/latest/system-thread.php#protecting-shared-data">official documentation</a>.</p>
 
     <h2 id="programming"><a class="h2-link" href="#programming">Programming in General</a><a class="back-to-top" href="#top" title="Top of the page"></a></h2>
 

--- a/tutorials/2.6/graphics-draw-fr.php
+++ b/tutorials/2.6/graphics-draw-fr.php
@@ -190,9 +190,9 @@ int main()
     <a href="./window-window.php" title="Tutoriel sur les fenêtres">tutoriel sur les fenêtres</a>.
 </p>
 <p class="important">
-    Bien que <?php class_link("RenderWindow") ?> permette de dessiner dans un thread et de gérer ses évènements dans un autre, ses autres fonctions ne sont pas
-    pour autant thread-safe. 
-    En particulier, vous devez arrêter le thread de dessin avant d'appeler la fonction <code>close</code>.
+    Vous pouvez dessiner et gérer les évènements d'une fenêtre dans deux threads différents car ces deux fonctionnalités sont complètement indépendantes.
+    La classe <?php class_link("RenderWindow") ?> n'est autrement pas thread-safe. 
+    En particulier, vous devez vous assurer que la fenêtre ne soit plus utilisée que dans un seul thread avant de la fermer.
 </p>
 
 <?php

--- a/tutorials/2.6/graphics-draw-fr.php
+++ b/tutorials/2.6/graphics-draw-fr.php
@@ -187,12 +187,14 @@ int main()
 </p>
 <p>
     Souvenez-vous : il faut toujours créer la fenêtre et gérer ses évènements dans le thread principal, pour un maximum de portabilité, comme expliqué dans le
-    <a href="./window-window.php" title="Tutoriel sur les fenêtres">tutoriel sur les fenêtres</a>.
+    <a href="./window-window-fr.php#choses-ce-savoir-ce-propos-des-fencotres" title="Tutoriel sur les fenêtres">tutoriel sur les fenêtres</a>.
 </p>
 <p class="important">
-    Vous pouvez dessiner et gérer les évènements d'une fenêtre dans deux threads différents car ces deux fonctionnalités sont complètement indépendantes.
-    La classe <?php class_link("RenderWindow") ?> n'est autrement pas thread-safe. 
-    En particulier, vous devez vous assurer que la fenêtre ne soit plus utilisée que dans un seul thread avant de la fermer.
+    L'exemple présentée ici n'est pas complètement thread-safe car un thread pourrait fermer la fenêtre pendant que l'autre l'utilise encore.
+    De manière générale, les objets SFML ne sont pas eux-mêmes thread-safes et vous devez vous-mêmes
+    <a href="./system-thread-fr.php#protceger-les-donncees-partagcees" title="Protéger les données partagées">protéger les données partagées</a>.<br/>
+    Notez que vous pouvez dessiner et gérer les évènements d'une fenêtre dans deux threads différents sans soucis car ces 
+    deux fonctionnalités sont complètement indépendantes.
 </p>
 
 <?php

--- a/tutorials/2.6/graphics-draw-fr.php
+++ b/tutorials/2.6/graphics-draw-fr.php
@@ -182,11 +182,17 @@ int main()
 }
 </code></pre>
 <p>
-    Comme vous pouvez le voir, vous n'avez même pas besoin d'activer la fenêtre dans le thread de dessin, SFML le fait automatiquement pour vous dès que nécessaire.
+    Remarque : vous n'avez pas besoin d'activer la fenêtre dans le thread de dessin, SFML le fait automatiquement pour vous dès que nécessaire à condition 
+    que le contexte OpenGL ait été correctement désactivé auparavant.
 </p>
 <p>
     Souvenez-vous : il faut toujours créer la fenêtre et gérer ses évènements dans le thread principal, pour un maximum de portabilité, comme expliqué dans le
     <a href="./window-window.php" title="Tutoriel sur les fenêtres">tutoriel sur les fenêtres</a>.
+</p>
+<p class="important">
+    Bien que <?php class_link("RenderWindow") ?> permette de dessiner dans un thread et de gérer ses évènements dans un autre, ses autres fonctions ne sont pas
+    pour autant thread-safe. 
+    En particulier, vous devez arrêter le thread de dessin avant d'appeler la fonction <code>close</code>.
 </p>
 
 <?php

--- a/tutorials/2.6/graphics-draw.php
+++ b/tutorials/2.6/graphics-draw.php
@@ -185,8 +185,9 @@ int main()
     <a href="./window-window.php" title="Window tutorial">window tutorial</a>.
 </p>
 <p class="important">
-    Even if <?php class_link("RenderWindow") ?> allows you to draw in a thread and handle its events in another, it's other functions are not thread-safe.
-    In particular, you must stop the rendering thread before calling the function <code>close</code>.
+    You can draw and handle the events of a window in two different threads because these two functionalities dont share anything.
+    The <?php class_link("RenderWindow") ?> class is otherwise not thread-safe.
+    In particular, you must ensure the window is only used in one thread before closing it.
 </p>
 
 <?php

--- a/tutorials/2.6/graphics-draw.php
+++ b/tutorials/2.6/graphics-draw.php
@@ -177,11 +177,16 @@ int main()
 }
 </code></pre>
 <p>
-    As you can see, you don't even need to bother with the activation of the window in the rendering thread, SFML does it automatically for you whenever it needs to be done.
+    Note : you don't need to activate the window in the rendering thread, SFML does it automatically for you whenever it needs 
+    to be done, as long as the OpenGL context is properly deactivate beforehand.
 </p>
 <p>
     Remember to always create the window and handle its events in the main thread for maximum portability. This is explained in the
     <a href="./window-window.php" title="Window tutorial">window tutorial</a>.
+</p>
+<p class="important">
+    Even if <?php class_link("RenderWindow") ?> allows you to draw in a thread and handle its events in another, it's other functions are not thread-safe.
+    In particular, you must stop the rendering thread before calling the function <code>close</code>.
 </p>
 
 <?php

--- a/tutorials/2.6/graphics-draw.php
+++ b/tutorials/2.6/graphics-draw.php
@@ -177,17 +177,19 @@ int main()
 }
 </code></pre>
 <p>
-    Note : you don't need to activate the window in the rendering thread, SFML does it automatically for you whenever it needs 
+    Note that you don't need to activate the window in the rendering thread, SFML does it automatically for you whenever it needs 
     to be done, as long as the OpenGL context is properly deactivate beforehand.
 </p>
 <p>
     Remember to always create the window and handle its events in the main thread for maximum portability. This is explained in the
-    <a href="./window-window.php" title="Window tutorial">window tutorial</a>.
+    <a href="./window-window.php#things-to-know-about-windows" title="Window tutorial">window tutorial</a>.
 </p>
 <p class="important">
-    You can draw and handle the events of a window in two different threads because these two functionalities dont share anything.
-    The <?php class_link("RenderWindow") ?> class is otherwise not thread-safe.
-    In particular, you must ensure the window is only used in one thread before closing it.
+    The example show here is not completely thread-safe because a thread could close the window while another still uses it.
+    Generally speaking, SFML objects are not themselves thread-safe and you need to 
+    <a href="./system-thread.php#protecting-shared-data" title="Protecting shared data">protect the shared data</a> yourself.<br/>
+    Note that you can draw and handle the events of a window in two different threads without issues because these 
+    two functionalities are independent.
 </p>
 
 <?php

--- a/tutorials/2.6/system-thread-fr.php
+++ b/tutorials/2.6/system-thread-fr.php
@@ -227,6 +227,10 @@ thread.wait();
     plusieurs threads en même temps. Et si l'opération en question n'est pas <em>thread-safe</em>, le résultat sera indéterminé (c'est-à-dire que
     cela pourrait planter ou corrompre des données).
 </p>
+<p class="important">
+    Les instances des classes fournies par SFML ne sont en général pas thread-safe. Vous devez les protéger si vous les utilisez 
+    dans plusieurs threads en même temps !
+</p>
 <p>
     Il existe plusieurs outils de programmation pour vous aider à protéger les variables partagées et rendre votre code thread-safe, ils sont
     appelés "primitives de synchronisation". Les plus communs sont les mutexs, les sémaphores, les conditions d'attente et les <em>spin locks</em>.

--- a/tutorials/2.6/system-thread-fr.php
+++ b/tutorials/2.6/system-thread-fr.php
@@ -228,8 +228,7 @@ thread.wait();
     cela pourrait planter ou corrompre des données).
 </p>
 <p class="important">
-    Les instances des classes fournies par SFML ne sont en général pas thread-safe. Vous devez les protéger si vous les utilisez 
-    dans plusieurs threads en même temps !
+    Les objets SFML ne sont en général pas thread-safe, Vous devez les protéger si vous les utilisez dans plusieurs threads en même temps !
 </p>
 <p>
     Il existe plusieurs outils de programmation pour vous aider à protéger les variables partagées et rendre votre code thread-safe, ils sont

--- a/tutorials/2.6/system-thread.php
+++ b/tutorials/2.6/system-thread.php
@@ -222,6 +222,9 @@ thread.wait();
     since threads run in parallel, it means that a variable or function might be used concurrently from several threads at the same time.
     If the operation is not <em>thread-safe</em>, it can lead to undefined behavior (ie. it might crash or corrupt data).
 </p>
+<p class="important">
+    Instances of classes defined by SFML are usually not thread-safe. You must protect them if you use them in multiple threads at the same time !
+</p>
 <p>
     Several programming tools exist to help you protect shared data and make your code thread-safe, these are called synchronization primitives. Common ones
     are mutexes, semaphores, condition variables and spin locks. They are all variants of the same concept: they protect a piece of code by allowing only

--- a/tutorials/2.6/system-thread.php
+++ b/tutorials/2.6/system-thread.php
@@ -223,7 +223,7 @@ thread.wait();
     If the operation is not <em>thread-safe</em>, it can lead to undefined behavior (ie. it might crash or corrupt data).
 </p>
 <p class="important">
-    Instances of classes defined by SFML are usually not thread-safe. You must protect them if you use them in multiple threads at the same time !
+    SFML objects are usually not thread-safe, you must protect them to use them in multiple threads at the same time !
 </p>
 <p>
     Several programming tools exist to help you protect shared data and make your code thread-safe, these are called synchronization primitives. Common ones


### PR DESCRIPTION
Related to https://github.com/SFML/SFML-Website/issues/127.
As discussed in https://github.com/SFML/SFML/issues/2892 and on Discord,
- Add comments about thread safety in relevant part of the tutorials and in the FAQ.
- Update comment about not needing to use `sf::RenderWindow#setActive` for coherency with previously modifier example.
- Fixing a link in the French tutorial redirected to English version.