### PR TITLE
Update macOS requirement for SFML 2.6+ on downloads and tutorials page

### DIFF
--- a/download/sfml/2.6.0/index-fr.php
+++ b/download/sfml/2.6.0/index-fr.php
@@ -73,10 +73,10 @@
     <tbody>
         <tr>
             <td class="os" rowspan="3">macOS</td>
-            <td><?php download_link('Clang', '64-bit (OS X 10.7+, compatible C++11 et libc++)', '5.07', '../../../files/SFML-2.6.0-macOS-clang-64-bit.tar.gz') ?></td>
+            <td><?php download_link('Clang', '64-bit (macOS 10.15+, compatible C++11 et libc++)', '5.07', '../../../files/SFML-2.6.0-macOS-clang-64-bit.tar.gz') ?></td>
         </tr>
         <tr>
-            <td><?php download_link('Clang', 'ARM64 (OS X 11.0+)', '5.02', '../../../files/SFML-2.6.0-macOS-clang-arm64.tar.gz') ?></td>
+            <td><?php download_link('Clang', 'ARM64 (macOS 11+)', '5.02', '../../../files/SFML-2.6.0-macOS-clang-arm64.tar.gz') ?></td>
         </tr>
         <tr>
             <td class="notice" colspan="3">

--- a/download/sfml/2.6.0/index.php
+++ b/download/sfml/2.6.0/index.php
@@ -72,10 +72,10 @@
     <tbody>
         <tr>
             <td class="os" rowspan="3">macOS</td>
-            <td><?php download_link('Clang', '64-bit (OS X 10.7+, compatible with C++11 and libc++)', '5.07', '../../../files/SFML-2.6.0-macOS-clang-64-bit.tar.gz') ?></td>
+            <td><?php download_link('Clang', '64-bit (macOS 10.15+, compatible with C++11 and libc++)', '5.07', '../../../files/SFML-2.6.0-macOS-clang-64-bit.tar.gz') ?></td>
         </tr>
         <tr>
-            <td><?php download_link('Clang', 'ARM64 (OS X 11.0+)', '5.02', '../../../files/SFML-2.6.0-macOS-clang-arm64.tar.gz') ?></td>
+            <td><?php download_link('Clang', 'ARM64 (macOS 11+)', '5.02', '../../../files/SFML-2.6.0-macOS-clang-arm64.tar.gz') ?></td>
         </tr>
         <tr>
             <td class="notice" colspan="3">

--- a/download/sfml/2.6.1/index-fr.php
+++ b/download/sfml/2.6.1/index-fr.php
@@ -73,10 +73,10 @@
     <tbody>
         <tr>
             <td class="os" rowspan="3">macOS</td>
-            <td><?php download_link('Clang', '64-bit (OS X 10.7+, compatible C++11 et libc++)', '5.07', '../../../files/SFML-2.6.1-macOS-clang-64-bit.tar.gz') ?></td>
+            <td><?php download_link('Clang', '64-bit (macOS 10.15+, compatible C++11 et libc++)', '5.07', '../../../files/SFML-2.6.1-macOS-clang-64-bit.tar.gz') ?></td>
         </tr>
         <tr>
-            <td><?php download_link('Clang', 'ARM64 (OS X 11.0+)', '5.02', '../../../files/SFML-2.6.1-macOS-clang-arm64.tar.gz') ?></td>
+            <td><?php download_link('Clang', 'ARM64 (macOS 11+)', '5.02', '../../../files/SFML-2.6.1-macOS-clang-arm64.tar.gz') ?></td>
         </tr>
         <tr>
             <td class="notice" colspan="3">

--- a/download/sfml/2.6.1/index.php
+++ b/download/sfml/2.6.1/index.php
@@ -72,10 +72,10 @@
     <tbody>
         <tr>
             <td class="os" rowspan="3">macOS</td>
-            <td><?php download_link('Clang', '64-bit (OS X 10.7+, compatible with C++11 and libc++)', '5.07', '../../../files/SFML-2.6.1-macOS-clang-64-bit.tar.gz') ?></td>
+            <td><?php download_link('Clang', '64-bit (macOS 10.15+, compatible with C++11 and libc++)', '5.07', '../../../files/SFML-2.6.1-macOS-clang-64-bit.tar.gz') ?></td>
         </tr>
         <tr>
-            <td><?php download_link('Clang', 'ARM64 (OS X 11.0+)', '5.02', '../../../files/SFML-2.6.1-macOS-clang-arm64.tar.gz') ?></td>
+            <td><?php download_link('Clang', 'ARM64 (macOS 11+)', '5.02', '../../../files/SFML-2.6.1-macOS-clang-arm64.tar.gz') ?></td>
         </tr>
         <tr>
             <td class="notice" colspan="3">

--- a/tutorials/2.6/start-osx-fr.php
+++ b/tutorials/2.6/start-osx-fr.php
@@ -25,7 +25,7 @@
     Tout ce dont vous avez besoin pour créer une application SFML est :
 </p>
 <ul>
-    <li>un Mac Intel 64-bit avec Lion ou ultérieur (10.7+)</li>
+    <li>un Mac Intel avec Catalina ou ultérieur (10.15+) ou un Mac Apple Silicon avec Big Sur ou ultérieur (11+)</li>
     <li>avec <a href="http://developer.apple.com/xcode/" title="Télécharger Xcode">Xcode</a> (les versions 4 et ultérieurs de l'EDI, qui est disponible sur l'<em>App Store</em>, sont supportées)</li>
     <li>avec clang et libc++ (fournis par Xcode).</li>
 </ul>

--- a/tutorials/2.6/start-osx.php
+++ b/tutorials/2.6/start-osx.php
@@ -23,7 +23,7 @@
     All you need to create an SFML application is:
 </p>
 <ul>
-    <li>A 64-bit Intel Mac with Lion or later (10.7+)</li>
+    <li>An Intel Mac with Catalina or later (10.15+) or an Apple Silicon Mac with Big Sur or later (11+)</li>
     <li><a href="http://developer.apple.com/xcode/" title="Download Xcode">Xcode</a> (versions 4 or above of the IDE, which is available on the <em>App Store</em>, are supported).</li>
     <li>Clang and libc++ (which are shipped by default with Xcode).</li>
 </ul>


### PR DESCRIPTION
Closes https://github.com/SFML/SFML-Website/issues/187.