### PR TITLE
Tutorial doc links update 2.6.0 -> 2.6.1

### DIFF
--- a/tutorials/2.6/header-fr.php
+++ b/tutorials/2.6/header-fr.php
@@ -1,6 +1,6 @@
 <?php
     $version = '2.6';
-    $full_version = '2.6.0';
+    $full_version = '2.6.1';
 
     require("../header-fr.php");
 ?>

--- a/tutorials/2.6/header.php
+++ b/tutorials/2.6/header.php
@@ -1,6 +1,6 @@
 <?php
     $version = '2.6';
-    $full_version = '2.6.0';
+    $full_version = '2.6.1';
 
     require("../header.php");
 ?>


### PR DESCRIPTION
website 2.6 tutorials currently link to 2.6.0 docs which contain a warning at the top of the page "Warning: this page refers to an old version of SFML. Click here to switch to the latest version."

now directly link to 2.6.1 (current highest stable version).