### PR TITLE
Remove "back to top" links

### DIFF
--- a/pages/tutorials/3.0/graphics/draw.md
+++ b/pages/tutorials/3.0/graphics/draw.md
@@ -60,7 +60,7 @@ Calling `display` is also mandatory, it takes what was drawn since the last ca
 This clear/draw/display cycle is the only good way to draw things. Don't try other strategies, such as keeping pixels from the previous frame, "erasing" pixels, or drawing once and calling display multiple times. You'll get strange results due to double-buffering.  
 Modern graphics hardware and APIs are *really* made for repeated clear/draw/display cycles where everything is completely refreshed at each iteration of the main loop. Don't be scared to draw 1000 sprites 60 times per second, you're far below the millions of triangles that your computer can handle.
 
-## [What can I draw now?](https://www.sfml-dev.org/tutorials/2.6/graphics-draw.php#what-can-i-draw-now)[](https://www.sfml-dev.org/tutorials/2.6/graphics-draw.php#top "Top of the page")
+## What can I draw now?
 
 Now that you have a main loop which is ready to draw, let's see what, and how, you can actually draw there.
 
@@ -73,7 +73,7 @@ Although they share some common properties, each of these entities come with the
 - [Shape tutorial](https://www.sfml-dev.org/tutorials/2.6/graphics-shape.php "Learn how to create and draw shapes")
 - [Vertex array tutorial](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php "Learn how to create and draw vertex arrays")
 
-## [Off-screen drawing](https://www.sfml-dev.org/tutorials/2.6/graphics-draw.php#off-screen-drawing)[](https://www.sfml-dev.org/tutorials/2.6/graphics-draw.php#top "Top of the page")
+## Off-screen drawing
 
 SFML also provides a way to draw to a texture instead of directly to a window. To do so, use a [`sf::RenderTexture`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1RenderTexture.php "sf::RenderTexture documentation") instead of a [`sf::RenderWindow`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1RenderWindow.php "sf::RenderWindow documentation"). It has the same functions for drawing, inherited from their common base: [`sf::RenderTarget`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1RenderTarget.php "sf::RenderTarget documentation").
 

--- a/pages/tutorials/3.0/graphics/shader.md
+++ b/pages/tutorials/3.0/graphics/shader.md
@@ -189,7 +189,7 @@ This special parameter automatically sets the texture of the entity being drawn 
 
 If you want to see nice examples of shaders in action, you can have a look at the Shader example in the SFML SDK.
 
-## [Using a sf::Shader with OpenGL code](https://www.sfml-dev.org/tutorials/2.6/graphics-shader.php#using-a-sfshader-with-opengl-code)[](https://www.sfml-dev.org/tutorials/2.6/graphics-shader.php#top "Top of the page")
+## Using a sf::Shader with OpenGL code
 
 If you're using OpenGL rather than the graphics entities of SFML, you can still use [`sf::Shader`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Shader.php "sf::Shader documentation") as a wrapper around an OpenGL program object and use it within your OpenGL code.
 

--- a/pages/tutorials/3.0/graphics/shape.md
+++ b/pages/tutorials/3.0/graphics/shape.md
@@ -73,7 +73,7 @@ Drawing a shape is as simple as drawing any other SFML entity:
 window.draw(shape);
 ```
 
-## [Built-in shape types](https://www.sfml-dev.org/tutorials/2.6/graphics-shape.php#built-in-shape-types)[](https://www.sfml-dev.org/tutorials/2.6/graphics-shape.php#top "Top of the page")
+## Built-in shape types
 
 ### Rectangles
 

--- a/pages/tutorials/3.0/graphics/sprite.md
+++ b/pages/tutorials/3.0/graphics/sprite.md
@@ -104,7 +104,7 @@ texture.setRepeated(true);
 
 This only works if your sprite is configured to show a rectangle which is larger than the texture, otherwise this property has no effect.
 
-## [Ok, can I have my sprite now?](https://www.sfml-dev.org/tutorials/2.6/graphics-sprite.php#ok-can-i-have-my-sprite-now)[](https://www.sfml-dev.org/tutorials/2.6/graphics-sprite.php#top "Top of the page")
+## Ok, can I have my sprite now?
 
 Yes, you can now create your sprite.
 
@@ -189,7 +189,7 @@ Additionally, using a single texture allows you to group static geometry into a 
 
 Try to keep this in mind when you create your animation sheets or your tilesets: Use as little textures as possible.
 
-## [Using sf::Texture with OpenGL code](https://www.sfml-dev.org/tutorials/2.6/graphics-sprite.php#using-sftexture-with-opengl-code)[](https://www.sfml-dev.org/tutorials/2.6/graphics-sprite.php#top "Top of the page")
+## Using sf::Texture with OpenGL code
 
 If you're using OpenGL rather than the graphics entities of SFML, you can still use [`sf::Texture`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Texture.php "sf::Texture documentation") as a wrapper around an OpenGL texture object and use it along with the rest of your OpenGL code.
 

--- a/pages/tutorials/3.0/graphics/text.md
+++ b/pages/tutorials/3.0/graphics/text.md
@@ -61,7 +61,7 @@ window.draw(text);
 
 Text can also be transformed: They have a position, an orientation and a scale. The functions involved are the same as for the [`sf::Sprite`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Sprite.php "sf::Sprite documentation") class and other SFML entities. They are explained in the [Transforming entities](https://www.sfml-dev.org/tutorials/2.6/graphics-transform.php "'Transforming entities' tutorial") tutorial.
 
-## [How to avoid problems with non-ASCII characters?](https://www.sfml-dev.org/tutorials/2.6/graphics-text.php#how-to-avoid-problems-with-non-ascii-characters)[](https://www.sfml-dev.org/tutorials/2.6/graphics-text.php#top "Top of the page")
+## How to avoid problems with non-ASCII characters?
 
 Handling non-ASCII characters (such as accented European, Arabic, or Chinese characters) correctly can be tricky. It requires a good understanding of the various encodings involved in the process of interpreting and drawing your text. To avoid having to bother with these encodings, there's a simple solution: Use _wide literal strings_.
 

--- a/pages/tutorials/3.0/graphics/transform.md
+++ b/pages/tutorials/3.0/graphics/transform.md
@@ -200,7 +200,7 @@ The function is named `getGlobalBounds` because it returns the bounding box of
 
 There's another function that returns the bounding box of the entity in its *local* coordinate system (before its transformations are applied): `getLocalBounds`. This function can be used to get the initial size of an entity, for example, or to perform more specific calculations.
 
-## [Object hierarchies (scene graph)](https://www.sfml-dev.org/tutorials/2.6/graphics-transform.php#object-hierarchies-scene-graph)[](https://www.sfml-dev.org/tutorials/2.6/graphics-transform.php#top "Top of the page")
+## Object hierarchies (scene graph)
 
 With the custom transforms seen previously, it becomes easy to implement a hierarchy of objects in which children are transformed relative to their parent. All you have to do is pass the combined transform from parent to children when you draw them, all the way until you reach the final drawable entities (sprites, text, shapes, vertex arrays or your own drawables).
 

--- a/pages/tutorials/3.0/graphics/vertex-array.md
+++ b/pages/tutorials/3.0/graphics/vertex-array.md
@@ -11,7 +11,7 @@ SFML provides simple classes for the most common 2D entities. And while more com
 
 To fill this gap, SFML provides a lower-level mechanism to draw things: Vertex arrays. As a matter of fact, vertex arrays are used internally by all other SFML classes. They allow for a more flexible definition of 2D entities, containing as many triangles as you need. They even allow drawing points or lines.
 
-## [What is a vertex, and why are they always in arrays?](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#what-is-a-vertex-and-why-are-they-always-in-arrays)[](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#top "Top of the page")
+## What is a vertex, and why are they always in arrays?
 
 A vertex is the smallest graphical entity that you can manipulate. In short, it is a graphical point: Naturally, it has a 2D position (x, y), but also a color, and a pair of texture coordinates. We'll go into the roles of these attributes later.
 
@@ -185,7 +185,7 @@ window.draw(vertices, states);
 
 To know more about transformations and the [`sf::Transform`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Transform.php "sf::Transform documentation") class, you can read the tutorial on [transforming entities](https://www.sfml-dev.org/tutorials/2.6/graphics-transform.php "Transforming entities tutorial").
 
-## [Creating an SFML-like entity](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#creating-an-sfml-like-entity)[](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#top "Top of the page")
+## Creating an SFML-like entity
 
 Now that you know how to define your own textured/colored/transformed entity, wouldn't it be nice to wrap it in an SFML-style class? Fortunately, SFML makes this easy for you by providing the [`sf::Drawable`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Drawable.php "sf::Drawable documentation") and [`sf::Transformable`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Transformable.php "sf::Transformable documentation") base classes. These two classes are the base of the built-in SFML entities [`sf::Sprite`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Sprite.php "sf::Sprite documentation"), [`sf::Text`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Text.php "sf::Text documentation") and [`sf::Shape`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Shape.php "sf::Shape documentation").
 
@@ -250,7 +250,7 @@ entity.setRotation(45.f);
 window.draw(entity);
 ```
 
-## [Example: tile map](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#example-tile-map)[](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#top "Top of the page")
+## Example: tile map
 
 With what we've seen above, let's create a class that encapsulates a tile map. The whole map will be contained in a single vertex array, therefore it will be super fast to draw. Note that we can apply this strategy only if the whole tile set can fit into a single texture. Otherwise, we would have to use at least one vertex array per texture.
 
@@ -373,7 +373,7 @@ int main()
 
 You can download the tileset used for this tilemap example [here](https://www.sfml-dev.org/tutorials/2.6/images/graphics-vertex-array-tilemap-tileset.png "Tilemap example tileset").
 
-## [Example: particle system](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#example-particle-system)[](https://www.sfml-dev.org/tutorials/2.6/graphics-vertex-array.php#top "Top of the page")
+## Example: particle system
 
 This second example implements another common entity: The particle system. This one is very simple, with no texture and as few parameters as possible. It demonstrates the use of the `sf::Points` primitive type with a dynamic vertex array which changes every frame.
 

--- a/pages/tutorials/3.0/graphics/view.md
+++ b/pages/tutorials/3.0/graphics/view.md
@@ -5,7 +5,7 @@
 
 # Controlling the 2D camera with views
 
-## [What is a view?](https://www.sfml-dev.org/tutorials/2.6/graphics-view.php#what-is-a-view)[](https://www.sfml-dev.org/tutorials/2.6/graphics-view.php#top "Top of the page")
+## What is a view?
 
 In games, it is not uncommon to have levels which are much bigger than the window itself. You only see is a small part of them. This is typically the case in RPGs, platform games, and many other genres. What developers might tend to forget is that they define entities *in a 2D world*, not directly in the window. The window is just a view, it shows a specific area of the whole world. It is perfectly fine to draw several views of the same world in parallel, or draw the world to a texture rather than to a window. The world itself remains unchanged, what changes is just the way it is seen.
 

--- a/pages/tutorials/3.0/network/http.md
+++ b/pages/tutorials/3.0/network/http.md
@@ -13,7 +13,7 @@ If you need more advanced features, such as secured HTTP (HTTPS) for example, yo
 
 For basic interaction between your program and an HTTP server, it should be enough.
 
-## [sf::Http](https://www.sfml-dev.org/tutorials/2.6/network-http.php#sfhttp)[](https://www.sfml-dev.org/tutorials/2.6/network-http.php#top "Top of the page")
+## sf::Http
 
 To communicate with an HTTP server you must use the [`sf::Http`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Http.php "sf::Http documentation") class.
 
@@ -80,7 +80,7 @@ std::cout << "body: " << response.getBody() << std::endl;
 
 The status code can be used to check whether the request was successfully processed or not: codes 2xx represent success, codes 3xx represent a redirection, codes 4xx represent client errors, codes 5xx represent server errors, and codes 10xx represent SFML specific errors which are *not* part of the HTTP standard.
 
-## [Example: sending scores to an online server](https://www.sfml-dev.org/tutorials/2.6/network-http.php#example-sending-scores-to-an-online-server)[](https://www.sfml-dev.org/tutorials/2.6/network-http.php#top "Top of the page")
+## Example: sending scores to an online server
 
 Here is a short example that demonstrates how to perform a simple task: Sending a score to an online database.
 

--- a/pages/tutorials/3.0/network/packet.md
+++ b/pages/tutorials/3.0/network/packet.md
@@ -18,7 +18,7 @@ The third problem is specific to how the TCP protocol works. Because it doesn't 
 
 You may of course face other problems with network programming, but these are the lowest-level ones, that almost everybody will have to solve. This is the reason why SFML provides some simple tools to avoid them.
 
-## [Fixed-size primitive types](https://www.sfml-dev.org/tutorials/2.6/network-packet.php#fixed-size-primitive-types)[](https://www.sfml-dev.org/tutorials/2.6/network-packet.php#top "Top of the page")
+## Fixed-size primitive types
 
 Since primitive types cannot be exchanged reliably on a network, the solution is simple: don't use them. SFML provides fixed-size types for data exchange: `sf::Int8, sf::Uint16, sf::Int32`, etc. These types are just typedefs to primitive types, but they are mapped to the type which has the expected size according to the platform. So they can (and must!) be used safely when you want to exchange data between two computers.
 

--- a/pages/tutorials/3.0/network/socket.md
+++ b/pages/tutorials/3.0/network/socket.md
@@ -224,7 +224,7 @@ sf::Socket::Status receiveWithTimeout(sf::TcpSocket& socket, sf::Packet& packet,
 }
 ```
 
-## [Non-blocking sockets](https://www.sfml-dev.org/tutorials/2.6/network-socket.php#non-blocking-sockets)[](https://www.sfml-dev.org/tutorials/2.6/network-socket.php#top "Top of the page")
+## Non-blocking sockets
 
 All sockets are blocking by default, but you can change this behaviour at any time with the `setBlocking` function.
 

--- a/pages/tutorials/3.0/system/stream.md
+++ b/pages/tutorials/3.0/system/stream.md
@@ -13,7 +13,7 @@ Sometimes you want to load files from unusual places, such as a compressed/encry
 
 In this tutorial you'll learn how to write and use your own derived input stream.
 
-## [And standard streams?](https://www.sfml-dev.org/tutorials/2.6/system-stream.php#and-standard-streams)[](https://www.sfml-dev.org/tutorials/2.6/system-stream.php#top "Top of the page")
+## And standard streams?
 
 Like many other languages, C++ already has a class for input data streams: `std::istream`. In fact it has two: `std::istream` is only the front-end, the abstract interface to the custom data is `std::streambuf`.
 

--- a/pages/tutorials/3.0/window/events.md
+++ b/pages/tutorials/3.0/window/events.md
@@ -9,7 +9,7 @@
 
 This tutorial is a detailed list of window events. It describes them, and shows how to (and how not to) use them.
 
-## [The sf::Event type](https://www.sfml-dev.org/tutorials/2.6/window-events.php#the-sfevent-type)[](https://www.sfml-dev.org/tutorials/2.6/window-events.php#top "Top of the page")
+## The sf::Event type
 
 Before dealing with events, it is important to understand what the [`sf::Event`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Event.php "sf::Event documentation") type is, and how to correctly use it. [`sf::Event`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1_1Event.php "sf::Event documentation") is a _union_, which means that only one of its members is valid at a time (remember your C++ lesson: all the members of a union share the same memory space). The valid member is the one that matches the event type, for example `event.key` for a `KeyPressed` event. Trying to read any other member will result in an undefined behavior (most likely: random or invalid values). It is important to never try to use an event member that doesn't match its type.
 

--- a/pages/tutorials/3.0/window/opengl.md
+++ b/pages/tutorials/3.0/window/opengl.md
@@ -69,7 +69,7 @@ std::cout << "version:" << settings.majorVersion << "." << settings.minorVersion
 
 OpenGL versions above 3.0 are supported by SFML (as long as your graphics driver can handle them). Support for selecting the profile of 3.2+ contexts and whether the context debug flag is set was added in SFML 2.3. The forward compatibility flag is not supported. By default, SFML creates 3.2+ contexts using the compatibility profile because the graphics module makes use of legacy OpenGL functionality. If you intend on using the graphics module, make sure to create your context without the core profile setting or the graphics module will not function correctly. On OS X, SFML supports creating OpenGL 3.2+ contexts using the core profile only. If you want to use the graphics module on OS X, you are limited to using a legacy context which implies OpenGL version 2.1.
 
-## [A typical OpenGL-with-SFML program](https://www.sfml-dev.org/tutorials/2.6/window-opengl.php#a-typical-opengl-with-sfml-program)[](https://www.sfml-dev.org/tutorials/2.6/window-opengl.php#top "Top of the page")
+## A typical OpenGL-with-SFML program
 
 Here is what a complete OpenGL program would look like with SFML:
 


### PR DESCRIPTION
Remove headers that still anchor back to the top of the page. Example:

```diff
-## [sf::Http](https://www.sfml-dev.org/tutorials/2.6/network-http.php#sfhttp)[](https://www.sfml-dev.org/tutorials/2.6/network-http.php#top "Top of the page")
+## sf::Http
```

All links hardcode to 2.6. So partially helps with #196