### PR TITLE
Change sf::UintX/sf::IntX to std::uintX_t/std::intX_t

### DIFF
--- a/pages/tutorials/3.0/audio/recording.md
+++ b/pages/tutorials/3.0/audio/recording.md
@@ -56,7 +56,7 @@ With the recorded data, you can then:
 - Access the raw audio data and analyze it, transform it, etc.
     
     ```cpp
-    const sf::Int16* samples = buffer.getSamples();
+    const std::int16_t* samples = buffer.getSamples();
     std::size_t count = buffer.getSampleCount();
     doSomething(samples, count);
     ```
@@ -118,7 +118,7 @@ class MyRecorder : public sf::SoundRecorder
         return true;
     }
 
-    virtual bool onProcessSamples(const sf::Int16* samples, std::size_t sampleCount)
+    virtual bool onProcessSamples(const std::int16_t* samples, std::size_t sampleCount)
     {
         // do something useful with the new chunk of samples
         ...

--- a/pages/tutorials/3.0/audio/sounds.md
+++ b/pages/tutorials/3.0/audio/sounds.md
@@ -43,7 +43,7 @@ SFML supports the audio file formats WAV, OGG/Vorbis and FLAC. MP3 is supported 
 You can also load a sound buffer directly from an array of samples, in the case they originate from another source:
 
 ```cpp
-std::vector<sf::Int16> samples = ...;
+std::vector<std::int16_t> samples = ...;
 buffer.loadFromSamples(&samples[0], samples.size(), 2, 44100);
 ```
 

--- a/pages/tutorials/3.0/audio/streams.md
+++ b/pages/tutorials/3.0/audio/streams.md
@@ -124,7 +124,7 @@ private:
         m_currentSample = static_cast<std::size_t>(timeOffset.asSeconds() * getSampleRate() * getChannelCount());
     }
 
-    std::vector<sf::Int16> m_samples;
+    std::vector<std::int16_t> m_samples;
     std::size_t m_currentSample;
 };
 

--- a/pages/tutorials/3.0/graphics/vertex-array.md
+++ b/pages/tutorials/3.0/graphics/vertex-array.md
@@ -412,7 +412,7 @@ public:
 
             // update the alpha (transparency) of the particle according to its lifetime
             float ratio = p.lifetime.asSeconds() / m_lifetime.asSeconds();
-            m_vertices[i].color.a = static_cast<sf::Uint8>(ratio * 255);
+            m_vertices[i].color.a = static_cast<std::uint8_t>(ratio * 255);
         }
     }
 

--- a/pages/tutorials/3.0/network/packet.md
+++ b/pages/tutorials/3.0/network/packet.md
@@ -20,7 +20,7 @@ You may of course face other problems with network programming, but these are th
 
 ## Fixed-size primitive types
 
-Since primitive types cannot be exchanged reliably on a network, the solution is simple: don't use them. SFML provides fixed-size types for data exchange: `sf::Int8, sf::Uint16, sf::Int32`, etc. These types are just typedefs to primitive types, but they are mapped to the type which has the expected size according to the platform. So they can (and must!) be used safely when you want to exchange data between two computers.
+Since primitive types cannot be exchanged reliably on a network, the solution is simple: don't use them. The C++ standard header `<cstdint>` provides fixed-size types for data exchange: `std::int8_t, std::uint16_t, std::int32_t`, etc. These types are just typedefs to primitive types, but they are mapped to the type which has the expected size according to the platform. So they can (and must!) be used safely when you want to exchange data between two computers.
 
 SFML only provides fixed-size *integer* types. Floating-point types should normally have their fixed-size equivalent too, but in practice this is not needed (at least on platforms where SFML runs), `float` and `double` types always have the same size, 32 bits and 64 bits respectively.
 
@@ -32,7 +32,7 @@ Packets have a programming interface similar to standard streams: you can insert
 
 ```cpp
 // on sending side
-sf::Uint16 x = 10;
+std::int16_t x = 10;
 std::string s = "hello";
 double d = 0.6;
 
@@ -42,7 +42,7 @@ packet << x << s << d;
 
 ```cpp
 // on receiving side
-sf::Uint16 x;
+std::uint16_t x;
 std::string s;
 double d;
 
@@ -85,7 +85,7 @@ Packets have overloads of their operators for all the primitive types and the mo
 ```cpp
 struct Character
 {
-    sf::Uint8 age;
+    std::uint8_t age;
     std::string name;
     float weight;
 };

--- a/pages/tutorials/3.0/network/packet.md
+++ b/pages/tutorials/3.0/network/packet.md
@@ -20,7 +20,7 @@ You may of course face other problems with network programming, but these are th
 
 ## Fixed-size primitive types
 
-Since primitive types cannot be exchanged reliably on a network, the solution is simple: don't use them. The C++ standard header `<cstdint>` provides fixed-size types for data exchange: `std::int8_t, std::uint16_t, std::int32_t`, etc. These types are just typedefs to primitive types, but they are mapped to the type which has the expected size according to the platform. So they can (and must!) be used safely when you want to exchange data between two computers.
+Since primitive types cannot be exchanged reliably on a network, the solution is simple: don't use them. The C++ standard header `<cstdint>` provides fixed-size types for data exchange: `std::int8_t, std::uint16_t, std::int32_t`, etc. These types can (and must!) be used safely when you want to exchange data between two computers.
 
 SFML only provides fixed-size *integer* types. Floating-point types should normally have their fixed-size equivalent too, but in practice this is not needed (at least on platforms where SFML runs), `float` and `double` types always have the same size, 32 bits and 64 bits respectively.
 

--- a/pages/tutorials/3.0/system/time.md
+++ b/pages/tutorials/3.0/system/time.md
@@ -33,9 +33,9 @@ Similarly, a [`sf::Time`](https://www.sfml-dev.org/documentation/3.0.0/classsf_1
 ```cpp
 sf::Time time = ...;
 
-sf::Int64 usec = time.asMicroseconds();
-sf::Int32 msec = time.asMilliseconds();
-float     sec  = time.asSeconds();
+std::int64_t usec = time.asMicroseconds();
+std::int32_t msec = time.asMilliseconds();
+float        sec  = time.asSeconds();
 ```
 
 Conversions with the C++ standard library's `std::chrono::duration` are supported in two ways.


### PR DESCRIPTION
`sf::UintX`/`sf::IntX` typedefs are no longer used in SFML 3.0.