### PR TITLE
Rename tutorial

### DIFF
--- a/pages/tutorials/3.0/getting-started/build-from-source.md
+++ b/pages/tutorials/3.0/getting-started/build-from-source.md
@@ -1,14 +1,11 @@
-# Compiling SFML with CMake
+# Building SFML from Source
 
 ## Introduction
 
-Admittedly, the title of this tutorial is a bit misleading.
-You will not *compile* SFML with CMake, because CMake is *not a compiler*.
-So, what is CMake?
-
+SFML's build process uses CMake.
 CMake is an open-source meta build system.
-Instead of building SFML, it builds what builds SFML: Visual Studio solutions, Code::Blocks projects, Linux Makefiles, XCode projects, etc.
-In fact it can generate the Makefiles or projects for any operating system and compiler of your choice.
+It will generate a build system which then does the actual compilation and linking.
+CMake generators include Visual Studio solutions, Code::Blocks projects, Ninja build files, Linux Makefiles, and XCode projects among others.
 It is similar to autoconf/automake or premake for those who are already familiar with these tools.
 
 CMake is used by many projects including well-known ones such as Minecraft: Bedrock Edition, LLVM, Blender, CLion, KDE, Ogre, and many more.

--- a/pages/tutorials/3.0/getting-started/code-blocks.md
+++ b/pages/tutorials/3.0/getting-started/code-blocks.md
@@ -18,7 +18,8 @@ Make sure you select the package which corresponds to the version that you use.
 If you are unsure, check which of the libgcc_s_sjlj-1.dll or libgcc_s_dw2-1.dll files is present in your MinGW/bin folder.
 If MinGW was installed along with Code::Blocks, you probably have an SJLJ version.
 
-If you feel like your version of GCC can't work with the precompiled SFML libraries, don't hesitate to [build SFML yourself](compile-with-cmake.md "How to compile SFML"), it's not complicated.
+If you feel like your version of GCC can't work with the precompiled SFML libraries, don't hesitate to [build SFML yourself](build-from-source.md "How to build SFML").
+It's not complicated.
 
 You can then unpack the SFML archive wherever you like.
 Copying headers and libraries to your installation of MinGW is not recommended, it's better to keep libraries in their own separate location, especially if you intend to use several versions of the same library, or several compilers.

--- a/pages/tutorials/3.0/getting-started/linux.md
+++ b/pages/tutorials/3.0/getting-started/linux.md
@@ -27,7 +27,7 @@ sudo apt-get install libsfml-dev
 Option 2 requires more work: you need to ensure all of SFML's dependencies including their development headers are available, make sure CMake is installed, and manually execute some commands.
 This will result in a package which is tailored to your system.
  
-If you want to go this way, there's a dedicated tutorial on [building SFML yourself](compile-with-cmake.md "How to compile SFML").
+If you want to go this way, there's a dedicated tutorial on [building SFML yourself](build-from-source.md "How to build SFML").
 
 Finally, option 3 is a good choice for quick installation if SFML is not available as an official package.
 Download the SDK from the [download page](https://www.sfml-dev.org/download.php "Go to the download page"), unpack it and copy the files to your preferred location: either a separate path in your personal folder (like */home/me/sfml*), or a standard path (like */usr/local*).

--- a/pages/tutorials/3.0/index.md
+++ b/pages/tutorials/3.0/index.md
@@ -7,7 +7,7 @@
 - [SFML and Code::Blocks (MinGW)](getting-started/code-blocks.md)
 - [SFML and Linux](getting-started/linux.md)
 - [SFML and Xcode (macOS)](getting-started/macos.md)
-- [Compiling SFML with CMake](getting-started/compile-with-cmake.md)
+- [Building SFML from Source](getting-started/build-from-source.md)
 
 ## System module
 


### PR DESCRIPTION
After changing the tutorial name, we no longer needed that opening paragraph because the title is no longer misleading.