### PR TITLE
Use raw string literals instead of preprocessor literal concatenation

### DIFF
--- a/pages/tutorials/3.0/graphics/shader.md
+++ b/pages/tutorials/3.0/graphics/shader.md
@@ -76,17 +76,19 @@ Shaders can also be loaded directly from strings, with the `loadFromMemory` func
 This can be useful if you want to embed the shader source directly into your program.
 
 ```cpp
-constexpr std::string_view vertexShader = \
-    "void main()" \
-    "{" \
-    "    ..." \
-    "}";
+constexpr std::string_view vertexShader = R"(
+void main()
+{
+    ... 
+}
+)";
 
-constexpr std::string_view fragmentShader = \
-    "void main()" \
-    "{" \
-    "    ..." \
-    "}";
+constexpr std::string_view fragmentShader = R"(
+void main()
+{
+    ... 
+}
+)";
 
 // load only the vertex shader
 if (!shader.loadFromMemory(vertexShader, sf::Shader::Vertex))


### PR DESCRIPTION
Raw string literals from C++11 are easier to read and they allow pasting shader code
from the internet directly without manual intervention.
also it adds the new lines automaticly so if someone did 
a syntax mistake in the shader code the OpenGL compiler
will tell you the line number instead of an extremely long
column number and line number 1.